### PR TITLE
Fix index overflow after last quiz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ const App: React.FC = () => {
       setGameState({
         playerHp: newPlayerHp,
         enemyHp: newEnemyHp,
-        currentQuizIndex: nextQuizIndex,
+        currentQuizIndex: isLastQuiz ? gameState.currentQuizIndex : nextQuizIndex,
         score: newScore,
         isGameOver: gameOver,
         playerWon: playerWon


### PR DESCRIPTION
## Summary
- avoid setting currentQuizIndex past available quizzes

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684f62f1555c8322910e86595a9e2d12