### PR TITLE
Add simple audio cues for attack effects

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Quiz, GameState } from '../types';
 import { CHARACTER_IMAGES, BACKGROUND_IMAGES } from '../constants';
+import { playAttackSound } from '../utils/sound';
 
 interface GameScreenProps {
   quizzes: Quiz[];
@@ -18,6 +19,12 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
 
   const playerHpPercentage = (gameState.playerHp / 20) * 100;
   const enemyHpPercentage = (gameState.enemyHp / 10) * 100;
+
+  useEffect(() => {
+    if (attackEffect) {
+      playAttackSound(attackEffect);
+    }
+  }, [attackEffect]);
 
   return (
     <div className="min-h-screen flex flex-col bg-black">

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -1,0 +1,18 @@
+export const playAttackSound = (type: 'player-attack' | 'enemy-attack'): void => {
+  try {
+    const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+    const ctx = new AudioCtx();
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = type === 'player-attack' ? 'sawtooth' : 'square';
+    oscillator.frequency.value = type === 'player-attack' ? 600 : 200;
+    gain.gain.setValueAtTime(0.1, ctx.currentTime);
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+    oscillator.start();
+    oscillator.stop(ctx.currentTime + 0.3);
+    oscillator.onended = () => ctx.close();
+  } catch (e) {
+    console.error('Audio error', e);
+  }
+};


### PR DESCRIPTION
## Summary
- add an audio helper that plays short tones for attacks
- trigger the sound when attackEffect updates in the game screen

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: cannot find React and other modules)*


------
https://chatgpt.com/codex/tasks/task_e_684f6e5225f0832289d67e547f4ff4da