### PR TITLE
Fix quiz index bounds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ const App: React.FC = () => {
       setGameState({
         playerHp: newPlayerHp,
         enemyHp: newEnemyHp,
-        currentQuizIndex: nextQuizIndex,
+        currentQuizIndex: Math.min(nextQuizIndex, quizzes.length - 1),
         score: newScore,
         isGameOver: gameOver,
         playerWon: playerWon


### PR DESCRIPTION
## Summary
- prevent current quiz index from exceeding last quiz

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684f720249c083229539c5d715057291