### PR TITLE
Add BGM playback

### DIFF
--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { getCategories, Category } from '../data/quizManager';
-import { CHARACTER_IMAGES, BACKGROUND_IMAGES } from '../constants';
+import { CHARACTER_IMAGES, BACKGROUND_IMAGES, BGM } from '../constants';
 
 interface CategorySelectProps {
   onCategorySelect: (categoryId: string) => void;
@@ -8,6 +8,18 @@ interface CategorySelectProps {
 
 const CategorySelect: React.FC<CategorySelectProps> = ({ onCategorySelect }) => {
   const categories = getCategories();
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const audio = new Audio(BGM.category);
+    audio.loop = true;
+    audioRef.current = audio;
+    audio.play().catch(() => {});
+    return () => {
+      audio.pause();
+      audio.currentTime = 0;
+    };
+  }, []);
 
   return (
     <div 

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Quiz, GameState } from '../types';
-import { CHARACTER_IMAGES, BACKGROUND_IMAGES } from '../constants';
+import { CHARACTER_IMAGES, BACKGROUND_IMAGES, BGM } from '../constants';
 
 interface GameScreenProps {
   quizzes: Quiz[];
@@ -11,6 +11,18 @@ interface GameScreenProps {
 
 const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, attackEffect }) => {
   const currentQuiz = quizzes[gameState.currentQuizIndex];
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const audio = new Audio(BGM.game);
+    audio.loop = true;
+    audioRef.current = audio;
+    audio.play().catch(() => {});
+    return () => {
+      audio.pause();
+      audio.currentTime = 0;
+    };
+  }, []);
   
   if (!currentQuiz) {
     return <div>クイズデータがありません</div>;

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { GameState } from '../types';
-import { BACKGROUND_IMAGES } from '../constants';
+import { BACKGROUND_IMAGES, BGM } from '../constants';
 
 interface ResultScreenProps {
   gameState: GameState;
@@ -9,6 +9,20 @@ interface ResultScreenProps {
 }
 
 const ResultScreen: React.FC<ResultScreenProps> = ({ gameState, onRestart, onBackToCategory }) => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const src = gameState.playerWon ? BGM.win : BGM.lose;
+    const audio = new Audio(src);
+    audioRef.current = audio;
+    audio.loop = false;
+    audio.play().catch(() => {});
+    return () => {
+      audio.pause();
+      audio.currentTime = 0;
+    };
+  }, [gameState.playerWon]);
+
   return (
     <div 
       className="min-h-screen relative flex items-center justify-center p-4"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,10 +7,18 @@ export const CHARACTER_IMAGES = {
   };
   
   // 背景画像のURL
-  export const BACKGROUND_IMAGES = {
+export const BACKGROUND_IMAGES = {
     title: "https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?w=1920&h=1080&fit=crop&crop=center&auto=format&q=80",
     category: "https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?w=1920&h=1080&fit=crop&crop=center&auto=format&q=80",
     // battle: "https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=1920&h=1080&fit=crop&crop=center&auto=format&q=80",
     battle: "https://github.com/oresama5656/GameData_Public/blob/main/background/sougen.png?raw=true",
-    result: "https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1920&h=1080&fit=crop&crop=center&auto=format&q=80"
-  };
+  result: "https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1920&h=1080&fit=crop&crop=center&auto=format&q=80"
+};
+
+// BGM ファイルのURL
+export const BGM = {
+  game: "https://github.com/oresama5656/GameData_Public/blob/main/ff7_battle.mp3?raw=true",
+  category: "https://github.com/oresama5656/GameData_Public/blob/main/FF_Prerude.mp3?raw=true",
+  win: "https://github.com/oresama5656/GameData_Public/blob/main/win.mp3?raw=true",
+  lose: "https://github.com/oresama5656/GameData_Public/blob/main/dq_zenmetsu.mp3?raw=true"
+};


### PR DESCRIPTION
## Summary
- configure audio URLs for BGM
- play category BGM on category screen
- play battle BGM on game screen
- play win/lose BGM on result screen

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684fb5a42bcc8322a00b34c205563feb