### PR TITLE
Implement dungeon floor system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,24 +9,30 @@ const App: React.FC = () => {
   const [currentScreen, setCurrentScreen] = useState<'category' | 'game' | 'result'>('category');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [attackEffect, setAttackEffect] = useState<'player-attack' | 'enemy-attack' | null>(null);
+  const getEnemyHpForFloor = (floor: number) => (floor % 10 === 0 ? 20 : 5);
+
   const [gameState, setGameState] = useState<GameState>({
     playerHp: 20,
-    enemyHp: 10,
+    enemyHp: getEnemyHpForFloor(1),
     currentQuizIndex: 0,
     score: 0,
     isGameOver: false,
-    playerWon: false
+    playerWon: false,
+    currentFloor: 1,
+    maxFloorReached: 1
   });
 
   const handleCategorySelect = (categoryId: string) => {
     setSelectedCategory(categoryId);
     setGameState({
       playerHp: 20,
-      enemyHp: 10,
+      enemyHp: getEnemyHpForFloor(1),
       currentQuizIndex: 0,
       score: 0,
       isGameOver: false,
-      playerWon: false
+      playerWon: false,
+      currentFloor: 1,
+      maxFloorReached: 1
     });
     setCurrentScreen('game');
   };
@@ -57,10 +63,20 @@ const App: React.FC = () => {
       setAttackEffect(null);
     }, 500);
 
+    let newCurrentFloor = gameState.currentFloor;
+    let newMaxFloor = gameState.maxFloorReached;
+    if (newEnemyHp <= 0) {
+      newCurrentFloor += 1;
+      newEnemyHp = getEnemyHpForFloor(newCurrentFloor);
+      if (newCurrentFloor > newMaxFloor) {
+        newMaxFloor = newCurrentFloor;
+      }
+    }
+
     const nextQuizIndex = gameState.currentQuizIndex + 1;
     const isLastQuiz = nextQuizIndex >= quizzes.length;
-    const gameOver = newPlayerHp <= 0 || newEnemyHp <= 0 || isLastQuiz;
-    const playerWon = newEnemyHp <= 0 || (isLastQuiz && newPlayerHp > 0);
+    const gameOver = newPlayerHp <= 0 || isLastQuiz;
+    const playerWon = isLastQuiz && newPlayerHp > 0;
 
     // ゲーム状態の更新を少し遅らせる（エフェクトを見せるため）
     setTimeout(() => {
@@ -70,7 +86,9 @@ const App: React.FC = () => {
         currentQuizIndex: nextQuizIndex,
         score: newScore,
         isGameOver: gameOver,
-        playerWon: playerWon
+        playerWon: playerWon,
+        currentFloor: newCurrentFloor,
+        maxFloorReached: newMaxFloor
       });
 
       if (gameOver) {
@@ -83,11 +101,13 @@ const App: React.FC = () => {
     setAttackEffect(null);
     setGameState({
       playerHp: 20,
-      enemyHp: 10,
+      enemyHp: getEnemyHpForFloor(1),
       currentQuizIndex: 0,
       score: 0,
       isGameOver: false,
-      playerWon: false
+      playerWon: false,
+      currentFloor: 1,
+      maxFloorReached: 1
     });
     setCurrentScreen('game');
   };

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -17,7 +17,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
   }
 
   const playerHpPercentage = (gameState.playerHp / 20) * 100;
-  const enemyHpPercentage = (gameState.enemyHp / 10) * 100;
+  const getEnemyHpForFloor = (floor: number) => (floor % 10 === 0 ? 20 : 5);
+  const enemyMaxHp = getEnemyHpForFloor(gameState.currentFloor);
+  const enemyHpPercentage = (gameState.enemyHp / enemyMaxHp) * 100;
 
   return (
     <div className="min-h-screen flex flex-col bg-black">
@@ -85,7 +87,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
               <div className="space-y-1">
                 <div className="flex justify-between text-xs text-gray-300">
                   <span>感染モンスター</span>
-                  <span>{gameState.enemyHp}/10</span>
+                  <span>{gameState.enemyHp}/{enemyMaxHp}</span>
                 </div>
                 <div className="w-32 sm:w-40 h-2 sm:h-3 bg-gray-800 rounded-full border border-gray-600 overflow-hidden">
                   <div 
@@ -146,6 +148,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
                 </span>
                 <span className="text-yellow-400 text-lg sm:text-xl">🧬</span>
               </div>
+              <span className="text-white text-xs sm:text-sm">Floor: {gameState.currentFloor}</span>
             </div>
             
             <h2 className="text-white text-base sm:text-lg md:text-xl font-bold mb-2 leading-tight">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,11 +5,13 @@ export interface Quiz {
     choices: string[];
   }
   
-  export interface GameState {
+export interface GameState {
     playerHp: number;
     enemyHp: number;
     currentQuizIndex: number;
     score: number;
     isGameOver: boolean;
     playerWon: boolean;
-  }
+    currentFloor: number;
+    maxFloorReached: number;
+}


### PR DESCRIPTION
## Summary
- track current floor and highest floor reached in `GameState`
- calculate enemy HP per floor (5 or 20 on every 10th floor)
- increment floor and reset enemy HP when a foe is defeated
- add floor display on `GameScreen`
- adjust enemy HP bar and text to reflect dynamic max HP

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684fa61497f883228842c2ed06010080