### PR TITLE
Add boss warning and image

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -11,9 +11,10 @@ interface GameScreenProps {
   onAnswer: (selectedAnswer: string) => void;
   attackEffect?: 'player-attack' | 'enemy-attack' | null;
   enemyImage: string;
+  showWarning?: boolean;
 }
 
-const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, attackEffect, enemyImage }) => {
+const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, attackEffect, enemyImage, showWarning }) => {
   const currentQuiz = quizzes[gameState.currentQuizIndex];
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -46,7 +47,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
   return (
     <div className="min-h-screen flex flex-col bg-black">
       {/* 戦闘シーン上半分 */}
-      <div 
+      <div
         className="flex-1 relative overflow-hidden"
         style={{
           backgroundImage: `url(${BACKGROUND_IMAGES.battle})`,
@@ -55,6 +56,13 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
           minHeight: '50vh'
         }}
       >
+
+        {/* ボス出現警告 */}
+        {showWarning && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/70">
+            <h1 className="text-red-600 text-5xl sm:text-6xl font-extrabold animate-pulse">WARNING</h1>
+          </div>
+        )}
         
         {/* 攻撃エフェクト */}
         {attackEffect === 'player-attack' && (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,6 +12,10 @@ export const ENEMY_IMAGES = [
   "https://github.com/oresama5656/GameData_Public/blob/main/asset_repo/v1/images/enemy_boss/angry_hosoya.png?raw=true",
   "https://github.com/oresama5656/GameData_Public/blob/main/Fukushi.png?raw=true"
 ];
+
+// ボスキャラクターの画像URL
+export const BOSS_IMAGE =
+  "https://github.com/oresama5656/GameData_Public/blob/main/enemy/fflike/engel.png?raw=true";
   
   // 背景画像のURL
 export const BACKGROUND_IMAGES = {


### PR DESCRIPTION
## Summary
- add boss image constant
- show WARNING overlay when boss spawns
- use boss image on boss floors

## Testing
- `npm run build` *(fails: cannot download dependencies)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3756da88322af6ecfe96e7fb694