### PR TITLE
Refactor sound utilities

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { CHARACTER_IMAGES, BACKGROUND_IMAGES, BGM } from '../constants';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Quiz, GameState } from '../types';
-import { playAttackSound } from '../utils/sound';
+import { playAttackSound, playWarningSound } from '../utils/sound';
 
 
 interface GameScreenProps {
@@ -43,6 +43,12 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
       playAttackSound(attackEffect);
     }
   }, [attackEffect]);
+
+  useEffect(() => {
+    if (showWarning) {
+      playWarningSound();
+    }
+  }, [showWarning]);
 
   return (
     <div className="min-h-screen flex flex-col bg-black">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -38,5 +38,7 @@ export const SOUND_EFFECTS = {
   // プレイヤーが敵を攻撃する音
   playerAttack: "https://github.com/oresama5656/GameData_Public/blob/main/audio/se/effect/slash.mp3?raw=true",
   // 敵がプレイヤーを攻撃する音
-  enemyAttack: "https://github.com/oresama5656/GameData_Public/blob/main/audio/se/effect/blow.mp3?raw=true"
+  enemyAttack: "https://github.com/oresama5656/GameData_Public/blob/main/audio/se/effect/blow.mp3?raw=true",
+  // ボス警告音
+  warning: "https://github.com/oresama5656/GameData_Public/blob/main/audio/se/effect/warning.mp3?raw=true"
 };

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -1,12 +1,24 @@
 import { SOUND_EFFECTS } from '../constants';
 
-export const playAttackSound = (type: 'player-attack' | 'enemy-attack'): void => {
+/**
+ * 汎用的なサウンド再生ヘルパー
+ * @param src 再生する効果音の URL
+ */
+const playSound = (src: string): void => {
   try {
-    const src = type === 'player-attack' ? SOUND_EFFECTS.playerAttack : SOUND_EFFECTS.enemyAttack;
     const audio = new Audio(src);
-    audio.volume = 1.0; // 音量を100%に設定
+    audio.volume = 1.0;
     audio.play().catch(() => {});
   } catch (e) {
     console.error('Audio error', e);
   }
+};
+
+export const playAttackSound = (type: 'player-attack' | 'enemy-attack'): void => {
+  const src = type === 'player-attack' ? SOUND_EFFECTS.playerAttack : SOUND_EFFECTS.enemyAttack;
+  playSound(src);
+};
+
+export const playWarningSound = (): void => {
+  playSound(SOUND_EFFECTS.warning);
 };


### PR DESCRIPTION
## Summary
- pull repeated audio logic into `playSound`
- call this helper from `playAttackSound` and `playWarningSound`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: missing React and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685363e5e1d4832296f5464a4539acb1