### PR TITLE
Enhance wrong answer feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,8 @@ const App: React.FC = () => {
         }, 250);
       }
     } else {
-      // 敵がまだ生きている場合は演出後に更新（0.6秒）
+      // 敵がまだ生きている場合は演出後に更新（不正解時は1秒追加）
+      const delay = isCorrect ? 600 : 1600;
       setTimeout(() => {
         setGameState({
           playerHp: newPlayerHp,
@@ -179,7 +180,7 @@ const App: React.FC = () => {
         if (gameOver) {
           setTimeout(() => setCurrentScreen('result'), 500);
         }
-      }, 600);
+        }, delay);
     }
   };
 

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -221,6 +221,16 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
             <p className="text-gray-300 text-xs sm:text-sm">
               🎯 正解して敵にダメージを与えよう！
             </p>
+            {isAnswerCorrect === false && (
+              <div className="mt-3 text-center">
+                <p className="text-red-500 text-xl sm:text-2xl md:text-3xl font-extrabold">
+                  不正解
+                </p>
+                <p className="text-white text-base sm:text-lg md:text-xl mt-1 font-semibold">
+                  正解：{currentQuiz.correct}
+                </p>
+              </div>
+            )}
           </div>
 
           {/* 選択肢エリア */}


### PR DESCRIPTION
## Summary
- show bold feedback text in the question area when answering incorrectly
- delay screen transition by 1s on wrong answers

## Testing
- `npm run build` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6853b130203c8322b48d49a79c1aa06e