### PR TITLE
Fix result screen floor display

### DIFF
--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -52,7 +52,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({ gameState, onRestart, onBac
     };
   }, [gameState.playerWon]);
 
-  const achievedFloor = gameState.score;
+  const achievedFloor = gameState.maxFloorReached;
 
   return (
     <div className="w-full h-screen overflow-hidden relative flex flex-col">


### PR DESCRIPTION
## Summary
- show `maxFloorReached` on result screen instead of score

## Testing
- `npm run build` *(fails: cannot find React types)*

------
https://chatgpt.com/codex/tasks/task_e_6853d8a86b8083229223ba33a7df6a1b