### PR TITLE
Implement random boss images and scaling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import CategorySelect from './components/CategorySelect';
 import GameScreen from './components/GameScreen';
 import ResultScreen from './components/ResultScreen';
 import { Quiz } from './types';
-import { ENEMY_IMAGES, BOSS_IMAGE } from './constants';
+import { ENEMY_IMAGES, BOSS_IMAGES } from './constants';
 
 // 不正解時に次の問題へ進むまでのウェイト時間（ms）
 // 適宜この値を変更して表示時間を調整できる
@@ -35,6 +35,12 @@ const App: React.FC = () => {
   const selectRandomEnemyImage = () => {
     const randomIndex = Math.floor(Math.random() * ENEMY_IMAGES.length);
     return ENEMY_IMAGES[randomIndex];
+  };
+
+  // ランダムにボスの画像を選択する関数
+  const selectRandomBossImage = () => {
+    const randomIndex = Math.floor(Math.random() * BOSS_IMAGES.length);
+    return BOSS_IMAGES[randomIndex];
   };
 
   const handleCategorySelect = (categoryId: string) => {
@@ -122,7 +128,7 @@ const App: React.FC = () => {
       }
 
       const isBossFloor = nextFloor % 10 === 0;
-      const newEnemyImage = isBossFloor ? BOSS_IMAGE : selectRandomEnemyImage();
+      const newEnemyImage = isBossFloor ? selectRandomBossImage() : selectRandomEnemyImage();
 
       if (isBossFloor) {
         setShowWarning(true);

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -40,6 +40,9 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
   const getEnemyHpForFloor = (floor: number) => (floor % 10 === 0 ? 20 : 5);
   const enemyMaxHp = getEnemyHpForFloor(gameState.currentFloor);
   const enemyHpPercentage = (gameState.enemyHp / enemyMaxHp) * 100;
+  const isBoss = gameState.currentFloor % 10 === 0;
+  const BOSS_SIZE_MULTIPLIER = 2; // ボス画像の表示倍率（変更する場合はここを調整）
+  const enemyScale = isBoss ? BOSS_SIZE_MULTIPLIER : 1;
 
   useEffect(() => {
     setSelectedAnswer(null);
@@ -142,11 +145,11 @@ const GameScreen: React.FC<GameScreenProps> = ({ quizzes, gameState, onAnswer, a
                     imageRendering: 'auto'
                   }}
                   // 敵が攻撃されたら右に移動（より高速化）
-                  animate={attackEffect === 'enemy-attack' ? { x: [0, 1000, 0] } : { x: 0, opacity: 1 }}
-                  initial={{ x: -200, opacity: 0 }}
+                  animate={attackEffect === 'enemy-attack' ? { x: [0, 1000, 0], scale: enemyScale } : { x: 0, opacity: 1, scale: enemyScale }}
+                  initial={{ x: -200, opacity: 0, scale: enemyScale }}
                   // 退場エフェクトを高速化（scale, blurエフェクトを削除してシンプルに）
-                  exit={{ opacity: 0, x: 200 }}
-                  transition={{ 
+                  exit={{ opacity: 0, x: 200, scale: enemyScale }}
+                  transition={{
                     duration: attackEffect === 'enemy-attack' ? 0.15 : 0.2,  // より高速化
                     ease: "easeOut"
                   }}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,9 +13,12 @@ export const ENEMY_IMAGES = [
   "https://github.com/oresama5656/GameData_Public/blob/main/Fukushi.png?raw=true"
 ];
 
-// ボスキャラクターの画像URL
-export const BOSS_IMAGE =
-  "https://github.com/oresama5656/GameData_Public/blob/main/enemy/fflike/engel.png?raw=true";
+// ボスキャラクターの画像URL（複数定義可能）
+export const BOSS_IMAGES = [
+  "https://github.com/oresama5656/GameData_Public/blob/main/enemy/fflike/engel.png?raw=true",
+  "https://github.com/oresama5656/GameData_Public/blob/main/enemy/fflike/satan_right.png?raw=true",
+  "https://github.com/oresama5656/GameData_Public/blob/main/asset_repo/v1/images/enemy_boss/angry_hosoya.png?raw=true"
+];
   
   // 背景画像のURL
 export const BACKGROUND_IMAGES = {


### PR DESCRIPTION
## Summary
- add list of boss images
- pick random boss image in App logic
- enlarge boss characters with configurable scale

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6853e46b56888322ba7129d2ca881e75