### PR TITLE
Add router while preserving game logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "framer-motion": "^10.18.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import TownMap from './pages/TownMap';
+import App from './App';
+
+const Root: React.FC = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<TownMap />} />
+      <Route path="/game" element={<App />} />
+    </Routes>
+  </BrowserRouter>
+);
+
+export default Root;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import Root from './Root'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 )

--- a/src/pages/TownMap.tsx
+++ b/src/pages/TownMap.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const TownMap: React.FC = () => (
+  <div className="w-screen h-screen flex items-center justify-center text-2xl text-white bg-black">
+    TownMap Placeholder
+  </div>
+);
+
+export default TownMap;


### PR DESCRIPTION
## Summary
- restore original `App` with quiz game logic
- add `Root` router to serve `TownMap` at `/` and the game at `/game`
- update app entry to render the new router

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6854369d1c208322be2155cbe30f2013