### PR TITLE
Add town map background

### DIFF
--- a/src/pages/TownMap.tsx
+++ b/src/pages/TownMap.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+// 画像を静的インポート
+import townBg from '/assets/map-town.png';
 
 const TownMap: React.FC = () => (
-  <div className="w-screen h-screen flex items-center justify-center text-2xl text-white bg-black">
+  <div
+    className="w-screen h-screen flex items-center justify-center text-2xl text-white"
+    style={{
+      backgroundImage: `url(${townBg})`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center'
+    }}
+  >
     TownMap Placeholder
   </div>
 );


### PR DESCRIPTION
## Summary
- show `/assets/map-town.png` as the fullscreen background on the TownMap page

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68543e325d1c8322b7b82f3d8d55a423