### PR TITLE
Fix asset path in TownMap

### DIFF
--- a/src/pages/TownMap.tsx
+++ b/src/pages/TownMap.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // 画像を静的インポート
-import townBg from '/assets/map-town.png';
+// アセットは相対パスで読み込む
+import townBg from '../assets/map-town.png';
 
 const TownMap: React.FC = () => (
   <div


### PR DESCRIPTION
## Summary
- fix relative import path for town map image

## Testing
- `npm run lint` *(fails: eslint config missing)*
- `npm run build` *(fails: modules not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68544045ffa88322a041d91a1a34193e