### PR TITLE
Add guild route with CategoryList and update TownMap navigation

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import TownMap from './pages/TownMap';
+import CategoryList from './pages/CategoryList';
 import App from './App';
 
 const Root: React.FC = () => (
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<TownMap />} />
+      <Route path="/guild/:guildId" element={<CategoryList />} />
       <Route path="/game" element={<App />} />
     </Routes>
   </BrowserRouter>

--- a/src/pages/CategoryList.tsx
+++ b/src/pages/CategoryList.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+const CategoryList: React.FC = () => {
+  const { guildId } = useParams();
+  return (
+    <div className="w-screen h-screen flex items-center justify-center text-2xl text-white bg-slate-900">
+      CategoryList Placeholder: {guildId}
+    </div>
+  );
+};
+
+export default CategoryList;

--- a/src/pages/TownMap.tsx
+++ b/src/pages/TownMap.tsx
@@ -3,30 +3,34 @@ import React from 'react';
 // アセットは相対パスで読み込む
 import townBg from '../assets/map-town.png';
 import { guilds } from '../data/guilds';
+import { useNavigate } from 'react-router-dom';
 
-const TownMap: React.FC = () => (
-  <div
-    className="w-screen h-screen flex items-center justify-center text-2xl text-white relative"
-    style={{
-      backgroundImage: `url(${townBg})`,
-      backgroundSize: 'cover',
-      backgroundPosition: 'center'
-    }}
-  >
-    {guilds.map(guild => (
-      <button
-        key={guild.id}
-        onClick={() => console.log(guild.id)}
-        className="absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-1 text-white text-center transition-transform hover:scale-105"
-        style={{ top: guild.position.top, left: guild.position.left }}
-      >
-        <span className="text-5xl drop-shadow">{guild.icon}</span>
-        <span className="text-sm bg-black/60 px-2 py-0.5 rounded">
-          {guild.name}
-        </span>
-      </button>
-    ))}
-  </div>
-);
+const TownMap: React.FC = () => {
+  const nav = useNavigate();
+  return (
+    <div
+      className="w-screen h-screen flex items-center justify-center text-2xl text-white relative"
+      style={{
+        backgroundImage: `url(${townBg})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center'
+      }}
+    >
+      {guilds.map(guild => (
+        <button
+          key={guild.id}
+          onClick={() => nav(`/guild/${guild.id}`)}
+          className="absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-1 text-white text-center transition-transform hover:scale-105"
+          style={{ top: guild.position.top, left: guild.position.left }}
+        >
+          <span className="text-5xl drop-shadow">{guild.icon}</span>
+          <span className="text-sm bg-black/60 px-2 py-0.5 rounded">
+            {guild.name}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
 
 export default TownMap;


### PR DESCRIPTION
## Summary
- add `CategoryList` page placeholder displaying the guild ID
- extend router in `Root.tsx` with `/guild/:guildId`
- navigate to guild pages from `TownMap`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6854463e8b948322893410422bada6ab