### PR TITLE
Add categories to guilds

### DIFF
--- a/src/data/guilds.ts
+++ b/src/data/guilds.ts
@@ -4,21 +4,66 @@ export const guilds = [
     name: '調剤ギルド',
     icon: '💊',
     position: { top: '30%', left: '25%' },
-    categories: []
+    categories: [
+      {
+        id: 'brand2generic',
+        name: '商品名→一般名',
+        icon: '💊',
+        description: '商品名から一般名を導く'
+      },
+      {
+        id: 'brand2effect',
+        name: '商品名→効果',
+        icon: '💊',
+        description: '商品名から効果を答える'
+      },
+      {
+        id: 'generic2effect',
+        name: '一般名→効果',
+        icon: '🧪',
+        description: '一般名から効果を答える'
+      },
+      {
+        id: 'brand2generic_diabetes',
+        name: '糖尿病薬：商品名→一般名',
+        icon: '🍬',
+        description: '糖尿病薬で商品名から一般名を導く'
+      },
+      {
+        id: 'antibiotics',
+        name: '抗生物質の分類',
+        icon: '🦠',
+        description: '抗生物質の分類を答える'
+      }
+    ]
   },
   {
     id: 'math',
     name: '数学ギルド',
     icon: '🔢',
     position: { top: '60%', left: '50%' },
-    categories: []
+    categories: [
+      {
+        id: 'simple_math',
+        name: '足し算',
+        icon: '📐',
+        description: '一桁の足し算'
+      }
+    ]
   },
   {
     id: 'english',
     name: '英語ギルド',
     icon: '🇬🇧',
     position: { top: '40%', left: '80%' },
-    categories: []
+    categories: [
+      {
+        id: 'text_length',
+        name: '文章表示テスト',
+        icon: '📖',
+        description: '長文表示テスト'
+      }
+    ]
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- add quiz category objects to each guild

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6854497ca7d48322aecac79b50be4cc4