### PR TITLE
Add star difficulty selection

### DIFF
--- a/src/pages/StarSelect.tsx
+++ b/src/pages/StarSelect.tsx
@@ -3,11 +3,19 @@ import { useParams } from 'react-router-dom';
 
 const StarSelect: React.FC = () => {
   const { guildId, catId } = useParams();
+
   return (
-    <div className="w-screen h-screen flex flex-col items-center justify-center text-white bg-slate-800 gap-4">
-      <h1 className="text-2xl font-bold">StarSelect Placeholder</h1>
-      <p>guild: {guildId}</p>
-      <p>category: {catId}</p>
+    <div className="min-h-screen bg-slate-800 text-white flex flex-col items-center p-6 gap-4">
+      <h1 className="text-xl font-bold">Select Difficulty</h1>
+      {[1, 2, 3, 4, 5].map(level => (
+        <button
+          key={level}
+          onClick={() => console.log(`star-${level}`)}
+          className="w-48 py-2 rounded-lg bg-yellow-600/80 hover:bg-yellow-500 transition"
+        >
+          {"★".repeat(level).padEnd(5, "☆")}
+        </button>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update `StarSelect` page to show ★1–★5 buttons for difficulty selection

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68544b8e1e848322b96444bebd005d74