### PR TITLE
Implement quiz placeholder route

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import TownMap from './pages/TownMap';
 import CategoryList from './pages/CategoryList';
 import StarSelect from './pages/StarSelect';
+import Quiz from './pages/Quiz';
 import App from './App';
 
 const Root: React.FC = () => (
@@ -11,6 +12,7 @@ const Root: React.FC = () => (
         <Route path="/" element={<TownMap />} />
         <Route path="/guild/:guildId" element={<CategoryList />} />
         <Route path="/guild/:guildId/category/:catId" element={<StarSelect />} />
+        <Route path="/quiz/:guildId/:catId/:starLvl" element={<Quiz />} />
         <Route path="/game" element={<App />} />
       </Routes>
   </BrowserRouter>

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+const Quiz: React.FC = () => {
+  const { guildId, catId, starLvl } = useParams();
+  return (
+    <div className="w-screen h-screen flex flex-col items-center justify-center bg-indigo-900 text-white gap-2">
+      <h1 className="text-2xl font-bold">Quiz Placeholder</h1>
+      <p>guild: {guildId}</p>
+      <p>category: {catId}</p>
+      <p>star: {starLvl}</p>
+    </div>
+  );
+};
+
+export default Quiz;

--- a/src/pages/StarSelect.tsx
+++ b/src/pages/StarSelect.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 const StarSelect: React.FC = () => {
   const { guildId, catId } = useParams();
+  const nav = useNavigate();
 
   return (
     <div className="min-h-screen bg-slate-800 text-white flex flex-col items-center p-6 gap-4">
@@ -10,7 +11,7 @@ const StarSelect: React.FC = () => {
       {[1, 2, 3, 4, 5].map(level => (
         <button
           key={level}
-          onClick={() => console.log(`star-${level}`)}
+          onClick={() => nav(`/quiz/${guildId}/${catId}/${level}`)}
           className="w-48 py-2 rounded-lg bg-yellow-600/80 hover:bg-yellow-500 transition"
         >
           {"★".repeat(level).padEnd(5, "☆")}


### PR DESCRIPTION
## Summary
- add placeholder Quiz page
- hook up `/quiz/:guildId/:catId/:starLvl` route
- navigate to quiz when star difficulty is chosen

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68544c66ab988322b38c2912a4a01a43