### PR TITLE
Implement fallback when loading GameScreen

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import TownMap from './pages/TownMap';
 import CategoryList from './pages/CategoryList';
-import GameScreen from './components/GameScreen';
+import GameScreen from './pages/GameScreen';
 
 const Root: React.FC = () => (
   <BrowserRouter>

--- a/src/pages/CategoryList.tsx
+++ b/src/pages/CategoryList.tsx
@@ -29,7 +29,7 @@ const CategoryList: React.FC = () => {
                   floors,
                   currentQuizIndex: 0,
                   starLevel: star,
-                  categoryName: cat.name,
+                  categoryId: cat.id,
                 },
               });
             }}

--- a/src/pages/GameScreen.tsx
+++ b/src/pages/GameScreen.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { quizData } from '../data/quizData';
+
+const GameScreen: React.FC = () => {
+  const location = useLocation() as { state?: any };
+  const { guildId, catId, starLvl } = useParams();
+
+  console.log('[GameScreen] location.state =', location.state);
+
+  let { quizzes, floors, currentQuizIndex, starLevel } = location.state ?? {};
+
+  if (!quizzes) {
+    const star = Number(starLvl) || 1;
+    starLevel = star;
+    floors = star === 1 ? 10 : 20;
+    quizzes = (quizData as any)[catId!] ?? [];
+    currentQuizIndex = 0;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-900 text-white p-4">
+      <h1 className="text-xl font-bold mb-2">Game Screen Placeholder</h1>
+      <p>guild: {guildId}</p>
+      <p>category: {catId}</p>
+      <p>starLevel: {starLevel}</p>
+      <p>floors: {floors}</p>
+      <p>quizzes: {quizzes.length}</p>
+      <p>currentQuizIndex: {currentQuizIndex}</p>
+    </div>
+  );
+};
+
+export default GameScreen;


### PR DESCRIPTION
## Summary
- ensure `CategoryList` always navigates with quiz state
- add new `GameScreen` page to read navigation state or fallback to URL params
- wire new `GameScreen` page into the router

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npx tsc -noEmit` *(fails: cannot find React type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685456b756348322a0a194f64bf6ec48