### PR TITLE
Add comprehensive math quiz sets

### DIFF
--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -22,7 +22,18 @@ const guilds = [
     name: '数学ギルド',
     icon: '🔢',
     position: { top: '60%', left: '50%' },
-    categories: ['simple_math']
+    categories: [
+      'simple_math',
+      'single_digit_subtraction',
+      'single_digit_multiplication',
+      'single_digit_division',
+      'double_digit_addition',
+      'double_digit_subtraction',
+      'double_digit_multiplication',
+      'double_digit_division',
+      'single_digit_mixed',
+      'double_digit_mixed'
+    ]
   },
   {
     id: 'english',

--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -48,6 +48,78 @@
     "clearFloor": 30
   },
   {
+    "id": "single_digit_subtraction",
+    "name": "引き算",
+    "description": "一桁の引き算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★",
+    "clearFloor": 30
+  },
+  {
+    "id": "single_digit_multiplication",
+    "name": "掛け算",
+    "description": "一桁の掛け算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★",
+    "clearFloor": 30
+  },
+  {
+    "id": "single_digit_division",
+    "name": "割り算",
+    "description": "一桁の割り算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★",
+    "clearFloor": 30
+  },
+  {
+    "id": "double_digit_addition",
+    "name": "二桁足し算",
+    "description": "二桁の足し算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★★",
+    "clearFloor": 30
+  },
+  {
+    "id": "double_digit_subtraction",
+    "name": "二桁引き算",
+    "description": "二桁の引き算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★★",
+    "clearFloor": 30
+  },
+  {
+    "id": "double_digit_multiplication",
+    "name": "二桁掛け算",
+    "description": "二桁の掛け算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★★",
+    "clearFloor": 30
+  },
+  {
+    "id": "double_digit_division",
+    "name": "二桁割り算",
+    "description": "二桁の割り算を答える問題です",
+    "icon": "🧮",
+    "difficulty": "★★",
+    "clearFloor": 30
+  },
+  {
+    "id": "single_digit_mixed",
+    "name": "一桁四則混合",
+    "description": "一桁の四則演算が混ざった問題です",
+    "icon": "🧮",
+    "difficulty": "★",
+    "clearFloor": 30
+  },
+  {
+    "id": "double_digit_mixed",
+    "name": "二桁四則混合",
+    "description": "二桁の四則演算が混ざった問題です",
+    "icon": "🧮",
+    "difficulty": "★★",
+    "clearFloor": 30
+  },
+  {
     "id": "text_length",
     "name": "文章表示テスト",
     "description": "長文や長い選択肢の表示確認用",

--- a/src/data/double_digit_addition.json
+++ b/src/data/double_digit_addition.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "77 + 32 =",
+    "correct": 109,
+    "choices": [
+      16,
+      -82,
+      109,
+      58
+    ]
+  },
+  {
+    "question": "83 + 49 =",
+    "correct": 132,
+    "choices": [
+      198,
+      132,
+      9,
+      -49
+    ]
+  },
+  {
+    "question": "99 + 81 =",
+    "correct": 180,
+    "choices": [
+      175,
+      -152,
+      47,
+      180
+    ]
+  },
+  {
+    "question": "73 + 64 =",
+    "correct": 137,
+    "choices": [
+      8,
+      137,
+      -55,
+      161
+    ]
+  },
+  {
+    "question": "45 + 18 =",
+    "correct": 63,
+    "choices": [
+      88,
+      63,
+      172,
+      100
+    ]
+  },
+  {
+    "question": "43 + 84 =",
+    "correct": 127,
+    "choices": [
+      -5,
+      82,
+      127,
+      -162
+    ]
+  },
+  {
+    "question": "80 + 12 =",
+    "correct": 92,
+    "choices": [
+      -96,
+      166,
+      92,
+      -124
+    ]
+  },
+  {
+    "question": "79 + 77 =",
+    "correct": 156,
+    "choices": [
+      156,
+      139,
+      -19,
+      92
+    ]
+  },
+  {
+    "question": "72 + 96 =",
+    "correct": 168,
+    "choices": [
+      -126,
+      168,
+      46,
+      98
+    ]
+  },
+  {
+    "question": "12 + 83 =",
+    "correct": 95,
+    "choices": [
+      42,
+      179,
+      95,
+      -75
+    ]
+  },
+  {
+    "question": "90 + 16 =",
+    "correct": 106,
+    "choices": [
+      106,
+      180,
+      -144,
+      124
+    ]
+  },
+  {
+    "question": "95 + 71 =",
+    "correct": 166,
+    "choices": [
+      85,
+      166,
+      -42,
+      97
+    ]
+  },
+  {
+    "question": "81 + 58 =",
+    "correct": 139,
+    "choices": [
+      5,
+      139,
+      93,
+      90
+    ]
+  },
+  {
+    "question": "26 + 80 =",
+    "correct": 106,
+    "choices": [
+      106,
+      189,
+      170,
+      56
+    ]
+  },
+  {
+    "question": "47 + 29 =",
+    "correct": 76,
+    "choices": [
+      76,
+      -114,
+      -45,
+      -53
+    ]
+  },
+  {
+    "question": "26 + 27 =",
+    "correct": 53,
+    "choices": [
+      53,
+      141,
+      -117,
+      17
+    ]
+  },
+  {
+    "question": "87 + 85 =",
+    "correct": 172,
+    "choices": [
+      172,
+      122,
+      -7,
+      163
+    ]
+  },
+  {
+    "question": "48 + 79 =",
+    "correct": 127,
+    "choices": [
+      21,
+      127,
+      -146,
+      155
+    ]
+  },
+  {
+    "question": "53 + 95 =",
+    "correct": 148,
+    "choices": [
+      -169,
+      48,
+      148,
+      197
+    ]
+  },
+  {
+    "question": "46 + 55 =",
+    "correct": 101,
+    "choices": [
+      -104,
+      199,
+      141,
+      101
+    ]
+  },
+  {
+    "question": "85 + 22 =",
+    "correct": 107,
+    "choices": [
+      10,
+      34,
+      107,
+      16
+    ]
+  },
+  {
+    "question": "65 + 24 =",
+    "correct": 89,
+    "choices": [
+      63,
+      -158,
+      105,
+      89
+    ]
+  },
+  {
+    "question": "26 + 55 =",
+    "correct": 81,
+    "choices": [
+      -189,
+      -75,
+      -42,
+      81
+    ]
+  },
+  {
+    "question": "92 + 55 =",
+    "correct": 147,
+    "choices": [
+      147,
+      -65,
+      174,
+      -113
+    ]
+  },
+  {
+    "question": "69 + 95 =",
+    "correct": 164,
+    "choices": [
+      -175,
+      140,
+      -55,
+      164
+    ]
+  },
+  {
+    "question": "35 + 73 =",
+    "correct": 108,
+    "choices": [
+      188,
+      -116,
+      108,
+      134
+    ]
+  },
+  {
+    "question": "94 + 29 =",
+    "correct": 123,
+    "choices": [
+      -158,
+      -19,
+      -153,
+      123
+    ]
+  },
+  {
+    "question": "25 + 50 =",
+    "correct": 75,
+    "choices": [
+      162,
+      32,
+      -63,
+      75
+    ]
+  },
+  {
+    "question": "32 + 64 =",
+    "correct": 96,
+    "choices": [
+      96,
+      -140,
+      22,
+      24
+    ]
+  },
+  {
+    "question": "54 + 81 =",
+    "correct": 135,
+    "choices": [
+      57,
+      138,
+      16,
+      135
+    ]
+  },
+  {
+    "question": "49 + 19 =",
+    "correct": 68,
+    "choices": [
+      68,
+      -4,
+      -71,
+      121
+    ]
+  },
+  {
+    "question": "21 + 88 =",
+    "correct": 109,
+    "choices": [
+      109,
+      137,
+      -64,
+      166
+    ]
+  },
+  {
+    "question": "49 + 50 =",
+    "correct": 99,
+    "choices": [
+      61,
+      -3,
+      56,
+      99
+    ]
+  },
+  {
+    "question": "63 + 44 =",
+    "correct": 107,
+    "choices": [
+      -58,
+      102,
+      107,
+      142
+    ]
+  },
+  {
+    "question": "65 + 79 =",
+    "correct": 144,
+    "choices": [
+      113,
+      144,
+      -104,
+      -122
+    ]
+  },
+  {
+    "question": "90 + 37 =",
+    "correct": 127,
+    "choices": [
+      127,
+      186,
+      134,
+      165
+    ]
+  },
+  {
+    "question": "51 + 31 =",
+    "correct": 82,
+    "choices": [
+      -140,
+      -93,
+      82,
+      168
+    ]
+  },
+  {
+    "question": "68 + 46 =",
+    "correct": 114,
+    "choices": [
+      -129,
+      -107,
+      114,
+      58
+    ]
+  },
+  {
+    "question": "37 + 60 =",
+    "correct": 97,
+    "choices": [
+      167,
+      97,
+      -182,
+      22
+    ]
+  },
+  {
+    "question": "87 + 79 =",
+    "correct": 166,
+    "choices": [
+      127,
+      166,
+      184,
+      24
+    ]
+  },
+  {
+    "question": "63 + 59 =",
+    "correct": 122,
+    "choices": [
+      122,
+      5,
+      83,
+      40
+    ]
+  },
+  {
+    "question": "59 + 59 =",
+    "correct": 118,
+    "choices": [
+      -102,
+      118,
+      75,
+      148
+    ]
+  },
+  {
+    "question": "53 + 19 =",
+    "correct": 72,
+    "choices": [
+      -65,
+      72,
+      164,
+      -108
+    ]
+  },
+  {
+    "question": "78 + 15 =",
+    "correct": 93,
+    "choices": [
+      47,
+      93,
+      -81,
+      69
+    ]
+  },
+  {
+    "question": "11 + 38 =",
+    "correct": 49,
+    "choices": [
+      127,
+      35,
+      131,
+      49
+    ]
+  },
+  {
+    "question": "19 + 60 =",
+    "correct": 79,
+    "choices": [
+      25,
+      79,
+      75,
+      50
+    ]
+  },
+  {
+    "question": "67 + 47 =",
+    "correct": 114,
+    "choices": [
+      114,
+      30,
+      -121,
+      -174
+    ]
+  },
+  {
+    "question": "50 + 50 =",
+    "correct": 100,
+    "choices": [
+      -117,
+      84,
+      -74,
+      100
+    ]
+  },
+  {
+    "question": "16 + 92 =",
+    "correct": 108,
+    "choices": [
+      108,
+      -175,
+      -1,
+      -94
+    ]
+  },
+  {
+    "question": "34 + 47 =",
+    "correct": 81,
+    "choices": [
+      96,
+      -178,
+      81,
+      -68
+    ]
+  },
+  {
+    "question": "58 + 14 =",
+    "correct": 72,
+    "choices": [
+      84,
+      189,
+      142,
+      72
+    ]
+  },
+  {
+    "question": "49 + 84 =",
+    "correct": 133,
+    "choices": [
+      -128,
+      79,
+      197,
+      133
+    ]
+  },
+  {
+    "question": "18 + 77 =",
+    "correct": 95,
+    "choices": [
+      95,
+      -33,
+      11,
+      22
+    ]
+  },
+  {
+    "question": "48 + 83 =",
+    "correct": 131,
+    "choices": [
+      -16,
+      131,
+      -79,
+      103
+    ]
+  },
+  {
+    "question": "16 + 45 =",
+    "correct": 61,
+    "choices": [
+      -98,
+      61,
+      145,
+      -81
+    ]
+  },
+  {
+    "question": "47 + 64 =",
+    "correct": 111,
+    "choices": [
+      111,
+      145,
+      -161,
+      155
+    ]
+  },
+  {
+    "question": "69 + 36 =",
+    "correct": 105,
+    "choices": [
+      -149,
+      -20,
+      -158,
+      105
+    ]
+  },
+  {
+    "question": "99 + 49 =",
+    "correct": 148,
+    "choices": [
+      -169,
+      26,
+      148,
+      -43
+    ]
+  },
+  {
+    "question": "76 + 74 =",
+    "correct": 150,
+    "choices": [
+      150,
+      -111,
+      149,
+      117
+    ]
+  },
+  {
+    "question": "95 + 76 =",
+    "correct": 171,
+    "choices": [
+      -19,
+      171,
+      57,
+      -192
+    ]
+  },
+  {
+    "question": "85 + 50 =",
+    "correct": 135,
+    "choices": [
+      135,
+      123,
+      36,
+      144
+    ]
+  },
+  {
+    "question": "21 + 17 =",
+    "correct": 38,
+    "choices": [
+      -33,
+      38,
+      -110,
+      -43
+    ]
+  },
+  {
+    "question": "96 + 45 =",
+    "correct": 141,
+    "choices": [
+      141,
+      -111,
+      -74,
+      172
+    ]
+  },
+  {
+    "question": "27 + 34 =",
+    "correct": 61,
+    "choices": [
+      175,
+      -166,
+      185,
+      61
+    ]
+  },
+  {
+    "question": "69 + 16 =",
+    "correct": 85,
+    "choices": [
+      96,
+      101,
+      85,
+      -175
+    ]
+  },
+  {
+    "question": "19 + 46 =",
+    "correct": 65,
+    "choices": [
+      51,
+      -169,
+      -76,
+      65
+    ]
+  },
+  {
+    "question": "18 + 59 =",
+    "correct": 77,
+    "choices": [
+      -119,
+      77,
+      168,
+      -183
+    ]
+  },
+  {
+    "question": "69 + 97 =",
+    "correct": 166,
+    "choices": [
+      21,
+      166,
+      36,
+      -85
+    ]
+  },
+  {
+    "question": "62 + 50 =",
+    "correct": 112,
+    "choices": [
+      112,
+      -133,
+      141,
+      -53
+    ]
+  },
+  {
+    "question": "98 + 60 =",
+    "correct": 158,
+    "choices": [
+      158,
+      -50,
+      100,
+      61
+    ]
+  },
+  {
+    "question": "30 + 77 =",
+    "correct": 107,
+    "choices": [
+      167,
+      107,
+      131,
+      130
+    ]
+  },
+  {
+    "question": "38 + 46 =",
+    "correct": 84,
+    "choices": [
+      84,
+      170,
+      -171,
+      110
+    ]
+  },
+  {
+    "question": "39 + 75 =",
+    "correct": 114,
+    "choices": [
+      160,
+      -53,
+      168,
+      114
+    ]
+  },
+  {
+    "question": "29 + 33 =",
+    "correct": 62,
+    "choices": [
+      141,
+      35,
+      62,
+      -76
+    ]
+  },
+  {
+    "question": "56 + 81 =",
+    "correct": 137,
+    "choices": [
+      118,
+      -172,
+      137,
+      -31
+    ]
+  },
+  {
+    "question": "21 + 46 =",
+    "correct": 67,
+    "choices": [
+      37,
+      -25,
+      67,
+      115
+    ]
+  },
+  {
+    "question": "19 + 54 =",
+    "correct": 73,
+    "choices": [
+      73,
+      134,
+      -144,
+      8
+    ]
+  },
+  {
+    "question": "16 + 40 =",
+    "correct": 56,
+    "choices": [
+      56,
+      -70,
+      140,
+      -174
+    ]
+  },
+  {
+    "question": "17 + 40 =",
+    "correct": 57,
+    "choices": [
+      128,
+      57,
+      183,
+      96
+    ]
+  },
+  {
+    "question": "75 + 22 =",
+    "correct": 97,
+    "choices": [
+      97,
+      -100,
+      76,
+      191
+    ]
+  },
+  {
+    "question": "87 + 28 =",
+    "correct": 115,
+    "choices": [
+      110,
+      7,
+      115,
+      11
+    ]
+  }
+]

--- a/src/data/double_digit_division.json
+++ b/src/data/double_digit_division.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "132 ÷ 12 =",
+    "correct": 11,
+    "choices": [
+      11,
+      3,
+      -14,
+      13
+    ]
+  },
+  {
+    "question": "165 ÷ 15 =",
+    "correct": 11,
+    "choices": [
+      19,
+      11,
+      4,
+      -2
+    ]
+  },
+  {
+    "question": "228 ÷ 12 =",
+    "correct": 19,
+    "choices": [
+      9,
+      19,
+      -19,
+      11
+    ]
+  },
+  {
+    "question": "240 ÷ 12 =",
+    "correct": 20,
+    "choices": [
+      1,
+      20,
+      -7,
+      8
+    ]
+  },
+  {
+    "question": "182 ÷ 13 =",
+    "correct": 14,
+    "choices": [
+      -12,
+      -6,
+      -1,
+      14
+    ]
+  },
+  {
+    "question": "110 ÷ 11 =",
+    "correct": 10,
+    "choices": [
+      10,
+      8,
+      0,
+      -15
+    ]
+  },
+  {
+    "question": "252 ÷ 18 =",
+    "correct": 14,
+    "choices": [
+      17,
+      -10,
+      14,
+      -7
+    ]
+  },
+  {
+    "question": "198 ÷ 18 =",
+    "correct": 11,
+    "choices": [
+      -15,
+      7,
+      11,
+      -7
+    ]
+  },
+  {
+    "question": "180 ÷ 15 =",
+    "correct": 12,
+    "choices": [
+      -11,
+      18,
+      12,
+      -5
+    ]
+  },
+  {
+    "question": "168 ÷ 12 =",
+    "correct": 14,
+    "choices": [
+      18,
+      -18,
+      -8,
+      14
+    ]
+  },
+  {
+    "question": "176 ÷ 11 =",
+    "correct": 16,
+    "choices": [
+      -11,
+      -7,
+      16,
+      -5
+    ]
+  },
+  {
+    "question": "288 ÷ 16 =",
+    "correct": 18,
+    "choices": [
+      18,
+      -5,
+      -19,
+      -1
+    ]
+  },
+  {
+    "question": "132 ÷ 12 =",
+    "correct": 11,
+    "choices": [
+      11,
+      1,
+      -14,
+      -10
+    ]
+  },
+  {
+    "question": "252 ÷ 14 =",
+    "correct": 18,
+    "choices": [
+      3,
+      -5,
+      7,
+      18
+    ]
+  },
+  {
+    "question": "260 ÷ 13 =",
+    "correct": 20,
+    "choices": [
+      20,
+      -16,
+      -17,
+      16
+    ]
+  },
+  {
+    "question": "209 ÷ 11 =",
+    "correct": 19,
+    "choices": [
+      -18,
+      19,
+      -3,
+      -8
+    ]
+  },
+  {
+    "question": "130 ÷ 13 =",
+    "correct": 10,
+    "choices": [
+      10,
+      -8,
+      2,
+      20
+    ]
+  },
+  {
+    "question": "130 ÷ 10 =",
+    "correct": 13,
+    "choices": [
+      3,
+      -7,
+      -9,
+      13
+    ]
+  },
+  {
+    "question": "285 ÷ 15 =",
+    "correct": 19,
+    "choices": [
+      18,
+      20,
+      -1,
+      19
+    ]
+  },
+  {
+    "question": "270 ÷ 15 =",
+    "correct": 18,
+    "choices": [
+      18,
+      -20,
+      -12,
+      -6
+    ]
+  },
+  {
+    "question": "288 ÷ 16 =",
+    "correct": 18,
+    "choices": [
+      -19,
+      18,
+      -1,
+      -7
+    ]
+  },
+  {
+    "question": "270 ÷ 18 =",
+    "correct": 15,
+    "choices": [
+      -2,
+      15,
+      -18,
+      -1
+    ]
+  },
+  {
+    "question": "306 ÷ 17 =",
+    "correct": 18,
+    "choices": [
+      15,
+      -2,
+      -8,
+      18
+    ]
+  },
+  {
+    "question": "240 ÷ 12 =",
+    "correct": 20,
+    "choices": [
+      14,
+      9,
+      -2,
+      20
+    ]
+  },
+  {
+    "question": "270 ÷ 18 =",
+    "correct": 15,
+    "choices": [
+      18,
+      -7,
+      -16,
+      15
+    ]
+  },
+  {
+    "question": "121 ÷ 11 =",
+    "correct": 11,
+    "choices": [
+      11,
+      20,
+      -20,
+      5
+    ]
+  },
+  {
+    "question": "238 ÷ 14 =",
+    "correct": 17,
+    "choices": [
+      17,
+      19,
+      1,
+      -19
+    ]
+  },
+  {
+    "question": "195 ÷ 13 =",
+    "correct": 15,
+    "choices": [
+      19,
+      -3,
+      15,
+      -8
+    ]
+  },
+  {
+    "question": "360 ÷ 20 =",
+    "correct": 18,
+    "choices": [
+      12,
+      10,
+      18,
+      5
+    ]
+  },
+  {
+    "question": "306 ÷ 18 =",
+    "correct": 17,
+    "choices": [
+      -6,
+      13,
+      4,
+      17
+    ]
+  },
+  {
+    "question": "228 ÷ 12 =",
+    "correct": 19,
+    "choices": [
+      -15,
+      19,
+      -6,
+      -19
+    ]
+  },
+  {
+    "question": "180 ÷ 12 =",
+    "correct": 15,
+    "choices": [
+      14,
+      -13,
+      15,
+      -4
+    ]
+  },
+  {
+    "question": "169 ÷ 13 =",
+    "correct": 13,
+    "choices": [
+      10,
+      11,
+      13,
+      19
+    ]
+  },
+  {
+    "question": "256 ÷ 16 =",
+    "correct": 16,
+    "choices": [
+      16,
+      -14,
+      19,
+      -19
+    ]
+  },
+  {
+    "question": "121 ÷ 11 =",
+    "correct": 11,
+    "choices": [
+      11,
+      -16,
+      -20,
+      -12
+    ]
+  },
+  {
+    "question": "342 ÷ 19 =",
+    "correct": 18,
+    "choices": [
+      19,
+      -11,
+      -1,
+      18
+    ]
+  },
+  {
+    "question": "272 ÷ 16 =",
+    "correct": 17,
+    "choices": [
+      10,
+      5,
+      17,
+      8
+    ]
+  },
+  {
+    "question": "288 ÷ 18 =",
+    "correct": 16,
+    "choices": [
+      9,
+      2,
+      -8,
+      16
+    ]
+  },
+  {
+    "question": "285 ÷ 19 =",
+    "correct": 15,
+    "choices": [
+      15,
+      -14,
+      11,
+      3
+    ]
+  },
+  {
+    "question": "285 ÷ 19 =",
+    "correct": 15,
+    "choices": [
+      17,
+      15,
+      8,
+      -16
+    ]
+  },
+  {
+    "question": "110 ÷ 10 =",
+    "correct": 11,
+    "choices": [
+      -14,
+      2,
+      11,
+      8
+    ]
+  },
+  {
+    "question": "323 ÷ 17 =",
+    "correct": 19,
+    "choices": [
+      1,
+      8,
+      -16,
+      19
+    ]
+  },
+  {
+    "question": "221 ÷ 17 =",
+    "correct": 13,
+    "choices": [
+      -8,
+      13,
+      20,
+      16
+    ]
+  },
+  {
+    "question": "252 ÷ 14 =",
+    "correct": 18,
+    "choices": [
+      18,
+      16,
+      10,
+      -2
+    ]
+  },
+  {
+    "question": "182 ÷ 13 =",
+    "correct": 14,
+    "choices": [
+      14,
+      17,
+      -16,
+      -17
+    ]
+  },
+  {
+    "question": "190 ÷ 19 =",
+    "correct": 10,
+    "choices": [
+      10,
+      -13,
+      -8,
+      -16
+    ]
+  },
+  {
+    "question": "224 ÷ 14 =",
+    "correct": 16,
+    "choices": [
+      15,
+      -17,
+      9,
+      16
+    ]
+  },
+  {
+    "question": "400 ÷ 20 =",
+    "correct": 20,
+    "choices": [
+      2,
+      -2,
+      12,
+      20
+    ]
+  },
+  {
+    "question": "187 ÷ 11 =",
+    "correct": 17,
+    "choices": [
+      -3,
+      14,
+      17,
+      -13
+    ]
+  },
+  {
+    "question": "143 ÷ 11 =",
+    "correct": 13,
+    "choices": [
+      -8,
+      -2,
+      -13,
+      13
+    ]
+  },
+  {
+    "question": "361 ÷ 19 =",
+    "correct": 19,
+    "choices": [
+      -7,
+      12,
+      -6,
+      19
+    ]
+  },
+  {
+    "question": "190 ÷ 19 =",
+    "correct": 10,
+    "choices": [
+      15,
+      14,
+      10,
+      -12
+    ]
+  },
+  {
+    "question": "208 ÷ 16 =",
+    "correct": 13,
+    "choices": [
+      20,
+      -6,
+      13,
+      4
+    ]
+  },
+  {
+    "question": "170 ÷ 10 =",
+    "correct": 17,
+    "choices": [
+      17,
+      -11,
+      -14,
+      15
+    ]
+  },
+  {
+    "question": "280 ÷ 14 =",
+    "correct": 20,
+    "choices": [
+      0,
+      20,
+      -14,
+      -9
+    ]
+  },
+  {
+    "question": "150 ÷ 15 =",
+    "correct": 10,
+    "choices": [
+      10,
+      18,
+      -20,
+      20
+    ]
+  },
+  {
+    "question": "180 ÷ 18 =",
+    "correct": 10,
+    "choices": [
+      -20,
+      0,
+      9,
+      10
+    ]
+  },
+  {
+    "question": "140 ÷ 14 =",
+    "correct": 10,
+    "choices": [
+      10,
+      13,
+      2,
+      15
+    ]
+  },
+  {
+    "question": "220 ÷ 11 =",
+    "correct": 20,
+    "choices": [
+      -2,
+      -17,
+      20,
+      14
+    ]
+  },
+  {
+    "question": "180 ÷ 15 =",
+    "correct": 12,
+    "choices": [
+      -6,
+      -15,
+      4,
+      12
+    ]
+  },
+  {
+    "question": "121 ÷ 11 =",
+    "correct": 11,
+    "choices": [
+      11,
+      -8,
+      1,
+      7
+    ]
+  },
+  {
+    "question": "209 ÷ 11 =",
+    "correct": 19,
+    "choices": [
+      19,
+      -16,
+      0,
+      3
+    ]
+  },
+  {
+    "question": "132 ÷ 11 =",
+    "correct": 12,
+    "choices": [
+      12,
+      16,
+      11,
+      3
+    ]
+  },
+  {
+    "question": "165 ÷ 15 =",
+    "correct": 11,
+    "choices": [
+      -12,
+      11,
+      -15,
+      -13
+    ]
+  },
+  {
+    "question": "224 ÷ 16 =",
+    "correct": 14,
+    "choices": [
+      -17,
+      1,
+      14,
+      -11
+    ]
+  },
+  {
+    "question": "110 ÷ 10 =",
+    "correct": 11,
+    "choices": [
+      -3,
+      11,
+      18,
+      -7
+    ]
+  },
+  {
+    "question": "169 ÷ 13 =",
+    "correct": 13,
+    "choices": [
+      17,
+      20,
+      -3,
+      13
+    ]
+  },
+  {
+    "question": "320 ÷ 16 =",
+    "correct": 20,
+    "choices": [
+      2,
+      -13,
+      20,
+      -20
+    ]
+  },
+  {
+    "question": "304 ÷ 16 =",
+    "correct": 19,
+    "choices": [
+      3,
+      18,
+      19,
+      13
+    ]
+  },
+  {
+    "question": "306 ÷ 18 =",
+    "correct": 17,
+    "choices": [
+      18,
+      8,
+      17,
+      -2
+    ]
+  },
+  {
+    "question": "209 ÷ 11 =",
+    "correct": 19,
+    "choices": [
+      19,
+      14,
+      -15,
+      -19
+    ]
+  },
+  {
+    "question": "288 ÷ 16 =",
+    "correct": 18,
+    "choices": [
+      -5,
+      2,
+      18,
+      16
+    ]
+  },
+  {
+    "question": "192 ÷ 12 =",
+    "correct": 16,
+    "choices": [
+      -9,
+      3,
+      16,
+      -16
+    ]
+  },
+  {
+    "question": "169 ÷ 13 =",
+    "correct": 13,
+    "choices": [
+      13,
+      4,
+      6,
+      -6
+    ]
+  },
+  {
+    "question": "192 ÷ 12 =",
+    "correct": 16,
+    "choices": [
+      16,
+      13,
+      -17,
+      3
+    ]
+  },
+  {
+    "question": "272 ÷ 16 =",
+    "correct": 17,
+    "choices": [
+      18,
+      17,
+      1,
+      -3
+    ]
+  },
+  {
+    "question": "198 ÷ 11 =",
+    "correct": 18,
+    "choices": [
+      14,
+      7,
+      -6,
+      18
+    ]
+  },
+  {
+    "question": "156 ÷ 12 =",
+    "correct": 13,
+    "choices": [
+      9,
+      11,
+      -10,
+      13
+    ]
+  },
+  {
+    "question": "100 ÷ 10 =",
+    "correct": 10,
+    "choices": [
+      -5,
+      10,
+      -14,
+      -1
+    ]
+  },
+  {
+    "question": "255 ÷ 17 =",
+    "correct": 15,
+    "choices": [
+      8,
+      11,
+      15,
+      -15
+    ]
+  },
+  {
+    "question": "342 ÷ 18 =",
+    "correct": 19,
+    "choices": [
+      16,
+      13,
+      6,
+      19
+    ]
+  }
+]

--- a/src/data/double_digit_mixed.json
+++ b/src/data/double_digit_mixed.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "18 x 10 =",
+    "correct": 180,
+    "choices": [
+      383,
+      -268,
+      -337,
+      180
+    ]
+  },
+  {
+    "question": "95 + 11 =",
+    "correct": 106,
+    "choices": [
+      82,
+      -86,
+      106,
+      -108
+    ]
+  },
+  {
+    "question": "320 ÷ 20 =",
+    "correct": 16,
+    "choices": [
+      -8,
+      16,
+      14,
+      -9
+    ]
+  },
+  {
+    "question": "32 + 75 =",
+    "correct": 107,
+    "choices": [
+      22,
+      4,
+      120,
+      107
+    ]
+  },
+  {
+    "question": "75 + 28 =",
+    "correct": 103,
+    "choices": [
+      182,
+      161,
+      147,
+      103
+    ]
+  },
+  {
+    "question": "10 x 17 =",
+    "correct": 170,
+    "choices": [
+      -225,
+      -277,
+      -260,
+      170
+    ]
+  },
+  {
+    "question": "272 ÷ 16 =",
+    "correct": 17,
+    "choices": [
+      3,
+      -8,
+      17,
+      -19
+    ]
+  },
+  {
+    "question": "17 x 13 =",
+    "correct": 221,
+    "choices": [
+      221,
+      -26,
+      -107,
+      78
+    ]
+  },
+  {
+    "question": "228 ÷ 19 =",
+    "correct": 12,
+    "choices": [
+      -14,
+      17,
+      -6,
+      12
+    ]
+  },
+  {
+    "question": "228 ÷ 19 =",
+    "correct": 12,
+    "choices": [
+      -18,
+      -19,
+      8,
+      12
+    ]
+  },
+  {
+    "question": "240 ÷ 20 =",
+    "correct": 12,
+    "choices": [
+      19,
+      -17,
+      12,
+      11
+    ]
+  },
+  {
+    "question": "77 + 31 =",
+    "correct": 108,
+    "choices": [
+      -36,
+      -124,
+      -25,
+      108
+    ]
+  },
+  {
+    "question": "12 x 14 =",
+    "correct": 168,
+    "choices": [
+      -219,
+      168,
+      -234,
+      -242
+    ]
+  },
+  {
+    "question": "180 ÷ 18 =",
+    "correct": 10,
+    "choices": [
+      6,
+      -9,
+      10,
+      15
+    ]
+  },
+  {
+    "question": "94 + 26 =",
+    "correct": 120,
+    "choices": [
+      186,
+      57,
+      178,
+      120
+    ]
+  },
+  {
+    "question": "15 - 49 =",
+    "correct": -34,
+    "choices": [
+      14,
+      73,
+      20,
+      -34
+    ]
+  },
+  {
+    "question": "24 - 98 =",
+    "correct": -74,
+    "choices": [
+      13,
+      -74,
+      -97,
+      -40
+    ]
+  },
+  {
+    "question": "221 ÷ 17 =",
+    "correct": 13,
+    "choices": [
+      8,
+      -7,
+      6,
+      13
+    ]
+  },
+  {
+    "question": "79 + 33 =",
+    "correct": 112,
+    "choices": [
+      112,
+      -129,
+      -60,
+      -21
+    ]
+  },
+  {
+    "question": "154 ÷ 14 =",
+    "correct": 11,
+    "choices": [
+      10,
+      11,
+      -9,
+      -20
+    ]
+  },
+  {
+    "question": "360 ÷ 20 =",
+    "correct": 18,
+    "choices": [
+      16,
+      18,
+      17,
+      -20
+    ]
+  },
+  {
+    "question": "14 x 18 =",
+    "correct": 252,
+    "choices": [
+      -317,
+      -204,
+      252,
+      53
+    ]
+  },
+  {
+    "question": "72 + 76 =",
+    "correct": 148,
+    "choices": [
+      -125,
+      148,
+      188,
+      162
+    ]
+  },
+  {
+    "question": "70 - 38 =",
+    "correct": 32,
+    "choices": [
+      32,
+      30,
+      -5,
+      -61
+    ]
+  },
+  {
+    "question": "12 x 12 =",
+    "correct": 144,
+    "choices": [
+      370,
+      144,
+      -155,
+      201
+    ]
+  },
+  {
+    "question": "10 x 19 =",
+    "correct": 190,
+    "choices": [
+      -225,
+      190,
+      -295,
+      -296
+    ]
+  },
+  {
+    "question": "33 - 72 =",
+    "correct": -39,
+    "choices": [
+      72,
+      85,
+      -13,
+      -39
+    ]
+  },
+  {
+    "question": "43 + 94 =",
+    "correct": 137,
+    "choices": [
+      137,
+      16,
+      187,
+      128
+    ]
+  },
+  {
+    "question": "17 x 13 =",
+    "correct": 221,
+    "choices": [
+      10,
+      363,
+      221,
+      132
+    ]
+  },
+  {
+    "question": "22 + 49 =",
+    "correct": 71,
+    "choices": [
+      -147,
+      -29,
+      -38,
+      71
+    ]
+  },
+  {
+    "question": "69 + 46 =",
+    "correct": 115,
+    "choices": [
+      115,
+      20,
+      -90,
+      7
+    ]
+  },
+  {
+    "question": "10 x 11 =",
+    "correct": 110,
+    "choices": [
+      -135,
+      110,
+      -98,
+      -319
+    ]
+  },
+  {
+    "question": "98 + 64 =",
+    "correct": 162,
+    "choices": [
+      -114,
+      -76,
+      -197,
+      162
+    ]
+  },
+  {
+    "question": "266 ÷ 14 =",
+    "correct": 19,
+    "choices": [
+      -20,
+      19,
+      14,
+      0
+    ]
+  },
+  {
+    "question": "285 ÷ 15 =",
+    "correct": 19,
+    "choices": [
+      -17,
+      17,
+      -10,
+      19
+    ]
+  },
+  {
+    "question": "18 x 13 =",
+    "correct": 234,
+    "choices": [
+      -324,
+      234,
+      -348,
+      194
+    ]
+  },
+  {
+    "question": "285 ÷ 19 =",
+    "correct": 15,
+    "choices": [
+      -12,
+      15,
+      -14,
+      14
+    ]
+  },
+  {
+    "question": "11 x 17 =",
+    "correct": 187,
+    "choices": [
+      -251,
+      71,
+      293,
+      187
+    ]
+  },
+  {
+    "question": "238 ÷ 17 =",
+    "correct": 14,
+    "choices": [
+      14,
+      -1,
+      10,
+      11
+    ]
+  },
+  {
+    "question": "72 - 50 =",
+    "correct": 22,
+    "choices": [
+      94,
+      -55,
+      46,
+      22
+    ]
+  },
+  {
+    "question": "57 - 81 =",
+    "correct": -24,
+    "choices": [
+      -60,
+      -66,
+      -24,
+      42
+    ]
+  },
+  {
+    "question": "210 ÷ 14 =",
+    "correct": 15,
+    "choices": [
+      2,
+      18,
+      15,
+      0
+    ]
+  },
+  {
+    "question": "260 ÷ 13 =",
+    "correct": 20,
+    "choices": [
+      20,
+      2,
+      -6,
+      3
+    ]
+  },
+  {
+    "question": "176 ÷ 16 =",
+    "correct": 11,
+    "choices": [
+      9,
+      -10,
+      8,
+      11
+    ]
+  },
+  {
+    "question": "64 + 43 =",
+    "correct": 107,
+    "choices": [
+      160,
+      -5,
+      107,
+      33
+    ]
+  },
+  {
+    "question": "143 ÷ 13 =",
+    "correct": 11,
+    "choices": [
+      11,
+      -2,
+      -9,
+      -7
+    ]
+  },
+  {
+    "question": "216 ÷ 12 =",
+    "correct": 18,
+    "choices": [
+      18,
+      -1,
+      -4,
+      -16
+    ]
+  },
+  {
+    "question": "224 ÷ 14 =",
+    "correct": 16,
+    "choices": [
+      1,
+      9,
+      -19,
+      16
+    ]
+  },
+  {
+    "question": "15 x 16 =",
+    "correct": 240,
+    "choices": [
+      -103,
+      -361,
+      -81,
+      240
+    ]
+  },
+  {
+    "question": "132 ÷ 12 =",
+    "correct": 11,
+    "choices": [
+      -7,
+      -14,
+      11,
+      -11
+    ]
+  },
+  {
+    "question": "87 + 23 =",
+    "correct": 110,
+    "choices": [
+      60,
+      -18,
+      110,
+      -157
+    ]
+  },
+  {
+    "question": "96 + 99 =",
+    "correct": 195,
+    "choices": [
+      -140,
+      -169,
+      195,
+      -38
+    ]
+  },
+  {
+    "question": "20 x 16 =",
+    "correct": 320,
+    "choices": [
+      320,
+      366,
+      365,
+      -229
+    ]
+  },
+  {
+    "question": "68 - 71 =",
+    "correct": -3,
+    "choices": [
+      -34,
+      -22,
+      82,
+      -3
+    ]
+  },
+  {
+    "question": "39 + 72 =",
+    "correct": 111,
+    "choices": [
+      5,
+      -129,
+      107,
+      111
+    ]
+  },
+  {
+    "question": "17 x 16 =",
+    "correct": 272,
+    "choices": [
+      272,
+      -234,
+      63,
+      336
+    ]
+  },
+  {
+    "question": "44 + 58 =",
+    "correct": 102,
+    "choices": [
+      54,
+      102,
+      15,
+      -151
+    ]
+  },
+  {
+    "question": "19 + 17 =",
+    "correct": 36,
+    "choices": [
+      34,
+      162,
+      36,
+      -110
+    ]
+  },
+  {
+    "question": "44 - 36 =",
+    "correct": 8,
+    "choices": [
+      8,
+      41,
+      100,
+      -42
+    ]
+  },
+  {
+    "question": "27 + 18 =",
+    "correct": 45,
+    "choices": [
+      41,
+      98,
+      148,
+      45
+    ]
+  },
+  {
+    "question": "140 ÷ 10 =",
+    "correct": 14,
+    "choices": [
+      -14,
+      7,
+      11,
+      14
+    ]
+  },
+  {
+    "question": "306 ÷ 18 =",
+    "correct": 17,
+    "choices": [
+      10,
+      17,
+      7,
+      -17
+    ]
+  },
+  {
+    "question": "342 ÷ 18 =",
+    "correct": 19,
+    "choices": [
+      16,
+      19,
+      8,
+      -17
+    ]
+  },
+  {
+    "question": "32 + 15 =",
+    "correct": 47,
+    "choices": [
+      57,
+      47,
+      -161,
+      23
+    ]
+  },
+  {
+    "question": "77 - 23 =",
+    "correct": 54,
+    "choices": [
+      54,
+      -74,
+      -76,
+      -21
+    ]
+  },
+  {
+    "question": "15 x 12 =",
+    "correct": 180,
+    "choices": [
+      337,
+      180,
+      131,
+      42
+    ]
+  },
+  {
+    "question": "73 - 50 =",
+    "correct": 23,
+    "choices": [
+      -1,
+      23,
+      67,
+      -74
+    ]
+  },
+  {
+    "question": "93 - 31 =",
+    "correct": 62,
+    "choices": [
+      -18,
+      -53,
+      6,
+      62
+    ]
+  },
+  {
+    "question": "30 - 20 =",
+    "correct": 10,
+    "choices": [
+      25,
+      -7,
+      10,
+      32
+    ]
+  },
+  {
+    "question": "84 + 84 =",
+    "correct": 168,
+    "choices": [
+      185,
+      168,
+      -27,
+      -56
+    ]
+  },
+  {
+    "question": "81 - 96 =",
+    "correct": -15,
+    "choices": [
+      -61,
+      -93,
+      30,
+      -15
+    ]
+  },
+  {
+    "question": "25 - 87 =",
+    "correct": -62,
+    "choices": [
+      -62,
+      95,
+      83,
+      -17
+    ]
+  },
+  {
+    "question": "18 x 19 =",
+    "correct": 342,
+    "choices": [
+      79,
+      342,
+      -60,
+      -62
+    ]
+  },
+  {
+    "question": "48 + 88 =",
+    "correct": 136,
+    "choices": [
+      136,
+      -139,
+      93,
+      -111
+    ]
+  },
+  {
+    "question": "22 + 73 =",
+    "correct": 95,
+    "choices": [
+      95,
+      -151,
+      -23,
+      -161
+    ]
+  },
+  {
+    "question": "225 ÷ 15 =",
+    "correct": 15,
+    "choices": [
+      -9,
+      -3,
+      15,
+      -4
+    ]
+  },
+  {
+    "question": "150 ÷ 10 =",
+    "correct": 15,
+    "choices": [
+      15,
+      13,
+      -7,
+      -5
+    ]
+  },
+  {
+    "question": "12 x 13 =",
+    "correct": 156,
+    "choices": [
+      -183,
+      -298,
+      156,
+      229
+    ]
+  },
+  {
+    "question": "56 - 20 =",
+    "correct": 36,
+    "choices": [
+      36,
+      -34,
+      -91,
+      -35
+    ]
+  },
+  {
+    "question": "96 + 74 =",
+    "correct": 170,
+    "choices": [
+      -147,
+      84,
+      -39,
+      170
+    ]
+  },
+  {
+    "question": "99 + 89 =",
+    "correct": 188,
+    "choices": [
+      188,
+      162,
+      -176,
+      124
+    ]
+  }
+]

--- a/src/data/double_digit_multiplication.json
+++ b/src/data/double_digit_multiplication.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "10 x 17 =",
+    "correct": 170,
+    "choices": [
+      121,
+      170,
+      -333,
+      72
+    ]
+  },
+  {
+    "question": "17 x 14 =",
+    "correct": 238,
+    "choices": [
+      -178,
+      -394,
+      238,
+      -292
+    ]
+  },
+  {
+    "question": "20 x 18 =",
+    "correct": 360,
+    "choices": [
+      -112,
+      166,
+      360,
+      36
+    ]
+  },
+  {
+    "question": "19 x 16 =",
+    "correct": 304,
+    "choices": [
+      -377,
+      244,
+      304,
+      -279
+    ]
+  },
+  {
+    "question": "18 x 16 =",
+    "correct": 288,
+    "choices": [
+      21,
+      97,
+      -35,
+      288
+    ]
+  },
+  {
+    "question": "19 x 18 =",
+    "correct": 342,
+    "choices": [
+      -52,
+      20,
+      342,
+      -115
+    ]
+  },
+  {
+    "question": "18 x 14 =",
+    "correct": 252,
+    "choices": [
+      252,
+      -181,
+      282,
+      69
+    ]
+  },
+  {
+    "question": "20 x 14 =",
+    "correct": 280,
+    "choices": [
+      -114,
+      280,
+      -290,
+      400
+    ]
+  },
+  {
+    "question": "13 x 15 =",
+    "correct": 195,
+    "choices": [
+      -220,
+      1,
+      195,
+      119
+    ]
+  },
+  {
+    "question": "10 x 15 =",
+    "correct": 150,
+    "choices": [
+      150,
+      -389,
+      240,
+      -92
+    ]
+  },
+  {
+    "question": "14 x 11 =",
+    "correct": 154,
+    "choices": [
+      154,
+      68,
+      -163,
+      205
+    ]
+  },
+  {
+    "question": "11 x 14 =",
+    "correct": 154,
+    "choices": [
+      154,
+      -385,
+      -351,
+      363
+    ]
+  },
+  {
+    "question": "19 x 11 =",
+    "correct": 209,
+    "choices": [
+      255,
+      -43,
+      316,
+      209
+    ]
+  },
+  {
+    "question": "19 x 11 =",
+    "correct": 209,
+    "choices": [
+      191,
+      278,
+      209,
+      -6
+    ]
+  },
+  {
+    "question": "10 x 19 =",
+    "correct": 190,
+    "choices": [
+      -207,
+      190,
+      -72,
+      14
+    ]
+  },
+  {
+    "question": "14 x 18 =",
+    "correct": 252,
+    "choices": [
+      -130,
+      102,
+      365,
+      252
+    ]
+  },
+  {
+    "question": "14 x 12 =",
+    "correct": 168,
+    "choices": [
+      -266,
+      92,
+      -57,
+      168
+    ]
+  },
+  {
+    "question": "12 x 19 =",
+    "correct": 228,
+    "choices": [
+      228,
+      -279,
+      394,
+      -95
+    ]
+  },
+  {
+    "question": "16 x 15 =",
+    "correct": 240,
+    "choices": [
+      109,
+      240,
+      136,
+      -225
+    ]
+  },
+  {
+    "question": "10 x 20 =",
+    "correct": 200,
+    "choices": [
+      108,
+      96,
+      200,
+      -199
+    ]
+  },
+  {
+    "question": "18 x 10 =",
+    "correct": 180,
+    "choices": [
+      15,
+      -35,
+      357,
+      180
+    ]
+  },
+  {
+    "question": "10 x 16 =",
+    "correct": 160,
+    "choices": [
+      85,
+      174,
+      -138,
+      160
+    ]
+  },
+  {
+    "question": "15 x 14 =",
+    "correct": 210,
+    "choices": [
+      -37,
+      210,
+      -192,
+      30
+    ]
+  },
+  {
+    "question": "16 x 16 =",
+    "correct": 256,
+    "choices": [
+      -95,
+      256,
+      330,
+      -372
+    ]
+  },
+  {
+    "question": "15 x 15 =",
+    "correct": 225,
+    "choices": [
+      -187,
+      225,
+      -362,
+      -193
+    ]
+  },
+  {
+    "question": "16 x 12 =",
+    "correct": 192,
+    "choices": [
+      -261,
+      192,
+      -309,
+      -283
+    ]
+  },
+  {
+    "question": "12 x 11 =",
+    "correct": 132,
+    "choices": [
+      280,
+      132,
+      -185,
+      -48
+    ]
+  },
+  {
+    "question": "11 x 10 =",
+    "correct": 110,
+    "choices": [
+      312,
+      84,
+      -104,
+      110
+    ]
+  },
+  {
+    "question": "16 x 16 =",
+    "correct": 256,
+    "choices": [
+      256,
+      -323,
+      140,
+      -247
+    ]
+  },
+  {
+    "question": "10 x 16 =",
+    "correct": 160,
+    "choices": [
+      -327,
+      160,
+      -377,
+      186
+    ]
+  },
+  {
+    "question": "14 x 13 =",
+    "correct": 182,
+    "choices": [
+      320,
+      -92,
+      182,
+      -219
+    ]
+  },
+  {
+    "question": "17 x 17 =",
+    "correct": 289,
+    "choices": [
+      379,
+      137,
+      -311,
+      289
+    ]
+  },
+  {
+    "question": "14 x 14 =",
+    "correct": 196,
+    "choices": [
+      137,
+      196,
+      389,
+      58
+    ]
+  },
+  {
+    "question": "14 x 16 =",
+    "correct": 224,
+    "choices": [
+      -230,
+      224,
+      83,
+      5
+    ]
+  },
+  {
+    "question": "17 x 14 =",
+    "correct": 238,
+    "choices": [
+      334,
+      -391,
+      141,
+      238
+    ]
+  },
+  {
+    "question": "13 x 20 =",
+    "correct": 260,
+    "choices": [
+      260,
+      52,
+      345,
+      -128
+    ]
+  },
+  {
+    "question": "10 x 10 =",
+    "correct": 100,
+    "choices": [
+      -48,
+      -385,
+      100,
+      227
+    ]
+  },
+  {
+    "question": "19 x 13 =",
+    "correct": 247,
+    "choices": [
+      -55,
+      -241,
+      247,
+      -47
+    ]
+  },
+  {
+    "question": "11 x 17 =",
+    "correct": 187,
+    "choices": [
+      -81,
+      187,
+      141,
+      281
+    ]
+  },
+  {
+    "question": "17 x 10 =",
+    "correct": 170,
+    "choices": [
+      170,
+      -314,
+      -332,
+      -81
+    ]
+  },
+  {
+    "question": "13 x 13 =",
+    "correct": 169,
+    "choices": [
+      23,
+      169,
+      -150,
+      261
+    ]
+  },
+  {
+    "question": "13 x 14 =",
+    "correct": 182,
+    "choices": [
+      -39,
+      176,
+      385,
+      182
+    ]
+  },
+  {
+    "question": "12 x 18 =",
+    "correct": 216,
+    "choices": [
+      163,
+      216,
+      280,
+      -147
+    ]
+  },
+  {
+    "question": "12 x 14 =",
+    "correct": 168,
+    "choices": [
+      -93,
+      -180,
+      168,
+      -282
+    ]
+  },
+  {
+    "question": "16 x 13 =",
+    "correct": 208,
+    "choices": [
+      208,
+      -53,
+      12,
+      61
+    ]
+  },
+  {
+    "question": "20 x 15 =",
+    "correct": 300,
+    "choices": [
+      300,
+      118,
+      -230,
+      368
+    ]
+  },
+  {
+    "question": "17 x 14 =",
+    "correct": 238,
+    "choices": [
+      -69,
+      341,
+      183,
+      238
+    ]
+  },
+  {
+    "question": "10 x 11 =",
+    "correct": 110,
+    "choices": [
+      -386,
+      62,
+      110,
+      -290
+    ]
+  },
+  {
+    "question": "14 x 17 =",
+    "correct": 238,
+    "choices": [
+      -109,
+      262,
+      60,
+      238
+    ]
+  },
+  {
+    "question": "14 x 16 =",
+    "correct": 224,
+    "choices": [
+      326,
+      376,
+      224,
+      15
+    ]
+  },
+  {
+    "question": "18 x 17 =",
+    "correct": 306,
+    "choices": [
+      261,
+      -193,
+      -185,
+      306
+    ]
+  },
+  {
+    "question": "11 x 12 =",
+    "correct": 132,
+    "choices": [
+      132,
+      270,
+      -2,
+      387
+    ]
+  },
+  {
+    "question": "16 x 19 =",
+    "correct": 304,
+    "choices": [
+      156,
+      -373,
+      304,
+      92
+    ]
+  },
+  {
+    "question": "10 x 12 =",
+    "correct": 120,
+    "choices": [
+      120,
+      -81,
+      -178,
+      -325
+    ]
+  },
+  {
+    "question": "16 x 15 =",
+    "correct": 240,
+    "choices": [
+      -148,
+      73,
+      -338,
+      240
+    ]
+  },
+  {
+    "question": "13 x 11 =",
+    "correct": 143,
+    "choices": [
+      -135,
+      143,
+      -22,
+      -166
+    ]
+  },
+  {
+    "question": "13 x 18 =",
+    "correct": 234,
+    "choices": [
+      -178,
+      264,
+      -349,
+      234
+    ]
+  },
+  {
+    "question": "15 x 15 =",
+    "correct": 225,
+    "choices": [
+      -64,
+      -252,
+      335,
+      225
+    ]
+  },
+  {
+    "question": "15 x 20 =",
+    "correct": 300,
+    "choices": [
+      296,
+      300,
+      -53,
+      97
+    ]
+  },
+  {
+    "question": "19 x 11 =",
+    "correct": 209,
+    "choices": [
+      209,
+      190,
+      -396,
+      72
+    ]
+  },
+  {
+    "question": "13 x 19 =",
+    "correct": 247,
+    "choices": [
+      -162,
+      -111,
+      247,
+      -293
+    ]
+  },
+  {
+    "question": "10 x 13 =",
+    "correct": 130,
+    "choices": [
+      211,
+      158,
+      155,
+      130
+    ]
+  },
+  {
+    "question": "19 x 16 =",
+    "correct": 304,
+    "choices": [
+      -391,
+      304,
+      -12,
+      230
+    ]
+  },
+  {
+    "question": "14 x 10 =",
+    "correct": 140,
+    "choices": [
+      140,
+      -157,
+      -71,
+      208
+    ]
+  },
+  {
+    "question": "14 x 17 =",
+    "correct": 238,
+    "choices": [
+      30,
+      238,
+      241,
+      -274
+    ]
+  },
+  {
+    "question": "20 x 15 =",
+    "correct": 300,
+    "choices": [
+      -171,
+      300,
+      -117,
+      -370
+    ]
+  },
+  {
+    "question": "15 x 17 =",
+    "correct": 255,
+    "choices": [
+      255,
+      -269,
+      -239,
+      -26
+    ]
+  },
+  {
+    "question": "16 x 15 =",
+    "correct": 240,
+    "choices": [
+      -188,
+      240,
+      47,
+      348
+    ]
+  },
+  {
+    "question": "16 x 10 =",
+    "correct": 160,
+    "choices": [
+      238,
+      160,
+      -279,
+      305
+    ]
+  },
+  {
+    "question": "17 x 14 =",
+    "correct": 238,
+    "choices": [
+      238,
+      155,
+      135,
+      -294
+    ]
+  },
+  {
+    "question": "14 x 18 =",
+    "correct": 252,
+    "choices": [
+      -301,
+      -390,
+      252,
+      192
+    ]
+  },
+  {
+    "question": "15 x 18 =",
+    "correct": 270,
+    "choices": [
+      160,
+      270,
+      -319,
+      145
+    ]
+  },
+  {
+    "question": "19 x 12 =",
+    "correct": 228,
+    "choices": [
+      38,
+      228,
+      -72,
+      -175
+    ]
+  },
+  {
+    "question": "20 x 14 =",
+    "correct": 280,
+    "choices": [
+      280,
+      -309,
+      -178,
+      -275
+    ]
+  },
+  {
+    "question": "16 x 12 =",
+    "correct": 192,
+    "choices": [
+      192,
+      -257,
+      -390,
+      190
+    ]
+  },
+  {
+    "question": "20 x 14 =",
+    "correct": 280,
+    "choices": [
+      174,
+      -240,
+      164,
+      280
+    ]
+  },
+  {
+    "question": "12 x 13 =",
+    "correct": 156,
+    "choices": [
+      239,
+      156,
+      -213,
+      289
+    ]
+  },
+  {
+    "question": "20 x 12 =",
+    "correct": 240,
+    "choices": [
+      240,
+      -216,
+      304,
+      -229
+    ]
+  },
+  {
+    "question": "12 x 19 =",
+    "correct": 228,
+    "choices": [
+      223,
+      228,
+      311,
+      -13
+    ]
+  },
+  {
+    "question": "17 x 13 =",
+    "correct": 221,
+    "choices": [
+      360,
+      334,
+      43,
+      221
+    ]
+  },
+  {
+    "question": "16 x 11 =",
+    "correct": 176,
+    "choices": [
+      176,
+      199,
+      258,
+      -94
+    ]
+  }
+]

--- a/src/data/double_digit_subtraction.json
+++ b/src/data/double_digit_subtraction.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "29 - 39 =",
+    "correct": -10,
+    "choices": [
+      1,
+      21,
+      -10,
+      -99
+    ]
+  },
+  {
+    "question": "93 - 44 =",
+    "correct": 49,
+    "choices": [
+      78,
+      49,
+      81,
+      8
+    ]
+  },
+  {
+    "question": "95 - 87 =",
+    "correct": 8,
+    "choices": [
+      17,
+      12,
+      8,
+      -58
+    ]
+  },
+  {
+    "question": "61 - 76 =",
+    "correct": -15,
+    "choices": [
+      64,
+      -15,
+      25,
+      4
+    ]
+  },
+  {
+    "question": "77 - 44 =",
+    "correct": 33,
+    "choices": [
+      33,
+      10,
+      -33,
+      -58
+    ]
+  },
+  {
+    "question": "51 - 82 =",
+    "correct": -31,
+    "choices": [
+      52,
+      34,
+      -77,
+      -31
+    ]
+  },
+  {
+    "question": "66 - 62 =",
+    "correct": 4,
+    "choices": [
+      4,
+      -94,
+      34,
+      68
+    ]
+  },
+  {
+    "question": "58 - 23 =",
+    "correct": 35,
+    "choices": [
+      35,
+      -37,
+      -25,
+      50
+    ]
+  },
+  {
+    "question": "81 - 30 =",
+    "correct": 51,
+    "choices": [
+      51,
+      43,
+      83,
+      72
+    ]
+  },
+  {
+    "question": "81 - 60 =",
+    "correct": 21,
+    "choices": [
+      21,
+      -50,
+      -39,
+      -73
+    ]
+  },
+  {
+    "question": "61 - 88 =",
+    "correct": -27,
+    "choices": [
+      -50,
+      -3,
+      -27,
+      -58
+    ]
+  },
+  {
+    "question": "53 - 72 =",
+    "correct": -19,
+    "choices": [
+      -45,
+      -19,
+      -56,
+      -6
+    ]
+  },
+  {
+    "question": "15 - 24 =",
+    "correct": -9,
+    "choices": [
+      17,
+      -9,
+      -41,
+      -90
+    ]
+  },
+  {
+    "question": "38 - 67 =",
+    "correct": -29,
+    "choices": [
+      -29,
+      -34,
+      -16,
+      -87
+    ]
+  },
+  {
+    "question": "66 - 35 =",
+    "correct": 31,
+    "choices": [
+      63,
+      31,
+      -42,
+      -51
+    ]
+  },
+  {
+    "question": "36 - 18 =",
+    "correct": 18,
+    "choices": [
+      -58,
+      -64,
+      18,
+      -22
+    ]
+  },
+  {
+    "question": "99 - 73 =",
+    "correct": 26,
+    "choices": [
+      -27,
+      -52,
+      38,
+      26
+    ]
+  },
+  {
+    "question": "17 - 58 =",
+    "correct": -41,
+    "choices": [
+      -54,
+      -84,
+      -41,
+      -69
+    ]
+  },
+  {
+    "question": "26 - 90 =",
+    "correct": -64,
+    "choices": [
+      -55,
+      -64,
+      -78,
+      41
+    ]
+  },
+  {
+    "question": "31 - 16 =",
+    "correct": 15,
+    "choices": [
+      15,
+      53,
+      -84,
+      -88
+    ]
+  },
+  {
+    "question": "12 - 45 =",
+    "correct": -33,
+    "choices": [
+      -56,
+      -79,
+      -84,
+      -33
+    ]
+  },
+  {
+    "question": "20 - 92 =",
+    "correct": -72,
+    "choices": [
+      -89,
+      -72,
+      77,
+      82
+    ]
+  },
+  {
+    "question": "27 - 20 =",
+    "correct": 7,
+    "choices": [
+      -86,
+      -19,
+      7,
+      37
+    ]
+  },
+  {
+    "question": "23 - 18 =",
+    "correct": 5,
+    "choices": [
+      5,
+      -79,
+      -99,
+      21
+    ]
+  },
+  {
+    "question": "47 - 35 =",
+    "correct": 12,
+    "choices": [
+      -87,
+      12,
+      50,
+      19
+    ]
+  },
+  {
+    "question": "21 - 94 =",
+    "correct": -73,
+    "choices": [
+      68,
+      27,
+      -73,
+      -57
+    ]
+  },
+  {
+    "question": "28 - 70 =",
+    "correct": -42,
+    "choices": [
+      -42,
+      75,
+      2,
+      -1
+    ]
+  },
+  {
+    "question": "83 - 48 =",
+    "correct": 35,
+    "choices": [
+      -17,
+      70,
+      35,
+      -43
+    ]
+  },
+  {
+    "question": "66 - 24 =",
+    "correct": 42,
+    "choices": [
+      76,
+      41,
+      42,
+      57
+    ]
+  },
+  {
+    "question": "13 - 68 =",
+    "correct": -55,
+    "choices": [
+      87,
+      -31,
+      61,
+      -55
+    ]
+  },
+  {
+    "question": "64 - 25 =",
+    "correct": 39,
+    "choices": [
+      17,
+      -62,
+      39,
+      -4
+    ]
+  },
+  {
+    "question": "88 - 44 =",
+    "correct": 44,
+    "choices": [
+      44,
+      -65,
+      -15,
+      35
+    ]
+  },
+  {
+    "question": "92 - 28 =",
+    "correct": 64,
+    "choices": [
+      -6,
+      -93,
+      45,
+      64
+    ]
+  },
+  {
+    "question": "35 - 27 =",
+    "correct": 8,
+    "choices": [
+      -27,
+      24,
+      87,
+      8
+    ]
+  },
+  {
+    "question": "43 - 18 =",
+    "correct": 25,
+    "choices": [
+      -41,
+      -99,
+      25,
+      -89
+    ]
+  },
+  {
+    "question": "60 - 20 =",
+    "correct": 40,
+    "choices": [
+      40,
+      -97,
+      45,
+      -68
+    ]
+  },
+  {
+    "question": "13 - 83 =",
+    "correct": -70,
+    "choices": [
+      -70,
+      -14,
+      72,
+      57
+    ]
+  },
+  {
+    "question": "58 - 59 =",
+    "correct": -1,
+    "choices": [
+      -15,
+      -1,
+      -73,
+      -46
+    ]
+  },
+  {
+    "question": "22 - 85 =",
+    "correct": -63,
+    "choices": [
+      45,
+      -63,
+      93,
+      -94
+    ]
+  },
+  {
+    "question": "80 - 38 =",
+    "correct": 42,
+    "choices": [
+      42,
+      -1,
+      -65,
+      24
+    ]
+  },
+  {
+    "question": "66 - 69 =",
+    "correct": -3,
+    "choices": [
+      -42,
+      -14,
+      -74,
+      -3
+    ]
+  },
+  {
+    "question": "89 - 30 =",
+    "correct": 59,
+    "choices": [
+      -56,
+      -44,
+      59,
+      49
+    ]
+  },
+  {
+    "question": "67 - 15 =",
+    "correct": 52,
+    "choices": [
+      -56,
+      97,
+      52,
+      6
+    ]
+  },
+  {
+    "question": "87 - 94 =",
+    "correct": -7,
+    "choices": [
+      1,
+      89,
+      -29,
+      -7
+    ]
+  },
+  {
+    "question": "80 - 48 =",
+    "correct": 32,
+    "choices": [
+      6,
+      75,
+      32,
+      -2
+    ]
+  },
+  {
+    "question": "79 - 78 =",
+    "correct": 1,
+    "choices": [
+      -62,
+      76,
+      81,
+      1
+    ]
+  },
+  {
+    "question": "52 - 37 =",
+    "correct": 15,
+    "choices": [
+      33,
+      15,
+      68,
+      5
+    ]
+  },
+  {
+    "question": "81 - 22 =",
+    "correct": 59,
+    "choices": [
+      48,
+      -58,
+      15,
+      59
+    ]
+  },
+  {
+    "question": "40 - 98 =",
+    "correct": -58,
+    "choices": [
+      -58,
+      -76,
+      84,
+      58
+    ]
+  },
+  {
+    "question": "37 - 71 =",
+    "correct": -34,
+    "choices": [
+      91,
+      63,
+      38,
+      -34
+    ]
+  },
+  {
+    "question": "15 - 46 =",
+    "correct": -31,
+    "choices": [
+      13,
+      96,
+      -31,
+      5
+    ]
+  },
+  {
+    "question": "67 - 32 =",
+    "correct": 35,
+    "choices": [
+      -8,
+      -77,
+      35,
+      -96
+    ]
+  },
+  {
+    "question": "46 - 53 =",
+    "correct": -7,
+    "choices": [
+      -7,
+      -46,
+      86,
+      27
+    ]
+  },
+  {
+    "question": "66 - 92 =",
+    "correct": -26,
+    "choices": [
+      57,
+      5,
+      -26,
+      -44
+    ]
+  },
+  {
+    "question": "50 - 32 =",
+    "correct": 18,
+    "choices": [
+      -96,
+      57,
+      -86,
+      18
+    ]
+  },
+  {
+    "question": "15 - 92 =",
+    "correct": -77,
+    "choices": [
+      16,
+      82,
+      -85,
+      -77
+    ]
+  },
+  {
+    "question": "96 - 70 =",
+    "correct": 26,
+    "choices": [
+      -42,
+      100,
+      10,
+      26
+    ]
+  },
+  {
+    "question": "91 - 32 =",
+    "correct": 59,
+    "choices": [
+      -82,
+      22,
+      -98,
+      59
+    ]
+  },
+  {
+    "question": "66 - 23 =",
+    "correct": 43,
+    "choices": [
+      -6,
+      43,
+      -11,
+      -9
+    ]
+  },
+  {
+    "question": "94 - 99 =",
+    "correct": -5,
+    "choices": [
+      -5,
+      -52,
+      35,
+      -30
+    ]
+  },
+  {
+    "question": "73 - 45 =",
+    "correct": 28,
+    "choices": [
+      28,
+      73,
+      41,
+      51
+    ]
+  },
+  {
+    "question": "93 - 53 =",
+    "correct": 40,
+    "choices": [
+      50,
+      -37,
+      24,
+      40
+    ]
+  },
+  {
+    "question": "19 - 60 =",
+    "correct": -41,
+    "choices": [
+      93,
+      -41,
+      -33,
+      -80
+    ]
+  },
+  {
+    "question": "80 - 95 =",
+    "correct": -15,
+    "choices": [
+      -69,
+      -51,
+      77,
+      -15
+    ]
+  },
+  {
+    "question": "89 - 20 =",
+    "correct": 69,
+    "choices": [
+      -77,
+      69,
+      1,
+      79
+    ]
+  },
+  {
+    "question": "68 - 21 =",
+    "correct": 47,
+    "choices": [
+      47,
+      83,
+      -45,
+      -14
+    ]
+  },
+  {
+    "question": "68 - 95 =",
+    "correct": -27,
+    "choices": [
+      -27,
+      65,
+      56,
+      -90
+    ]
+  },
+  {
+    "question": "13 - 78 =",
+    "correct": -65,
+    "choices": [
+      96,
+      95,
+      -65,
+      -56
+    ]
+  },
+  {
+    "question": "49 - 64 =",
+    "correct": -15,
+    "choices": [
+      -18,
+      -52,
+      -15,
+      68
+    ]
+  },
+  {
+    "question": "68 - 51 =",
+    "correct": 17,
+    "choices": [
+      17,
+      78,
+      -8,
+      -10
+    ]
+  },
+  {
+    "question": "54 - 87 =",
+    "correct": -33,
+    "choices": [
+      -69,
+      55,
+      -68,
+      -33
+    ]
+  },
+  {
+    "question": "80 - 72 =",
+    "correct": 8,
+    "choices": [
+      8,
+      -89,
+      -81,
+      -58
+    ]
+  },
+  {
+    "question": "59 - 59 =",
+    "correct": 0,
+    "choices": [
+      -92,
+      -45,
+      98,
+      0
+    ]
+  },
+  {
+    "question": "22 - 30 =",
+    "correct": -8,
+    "choices": [
+      -38,
+      30,
+      18,
+      -8
+    ]
+  },
+  {
+    "question": "12 - 43 =",
+    "correct": -31,
+    "choices": [
+      -31,
+      -16,
+      -74,
+      -91
+    ]
+  },
+  {
+    "question": "81 - 56 =",
+    "correct": 25,
+    "choices": [
+      -70,
+      21,
+      25,
+      -91
+    ]
+  },
+  {
+    "question": "96 - 53 =",
+    "correct": 43,
+    "choices": [
+      83,
+      43,
+      -26,
+      6
+    ]
+  },
+  {
+    "question": "86 - 83 =",
+    "correct": 3,
+    "choices": [
+      3,
+      94,
+      -20,
+      -39
+    ]
+  },
+  {
+    "question": "22 - 24 =",
+    "correct": -2,
+    "choices": [
+      -27,
+      47,
+      -2,
+      -68
+    ]
+  },
+  {
+    "question": "68 - 20 =",
+    "correct": 48,
+    "choices": [
+      48,
+      57,
+      79,
+      1
+    ]
+  },
+  {
+    "question": "59 - 98 =",
+    "correct": -39,
+    "choices": [
+      -39,
+      -7,
+      -1,
+      57
+    ]
+  }
+]

--- a/src/data/quizData.ts
+++ b/src/data/quizData.ts
@@ -7,6 +7,15 @@ import generic2effect from './generic2effect.json';
 import brand2generic_diabetes from './brand2generic_diabetes.json';
 import antibiotics from './antibiotics.json';
 import simple_math from './simple_math.json';
+import single_digit_subtraction from './single_digit_subtraction.json';
+import single_digit_multiplication from './single_digit_multiplication.json';
+import single_digit_division from './single_digit_division.json';
+import double_digit_addition from './double_digit_addition.json';
+import double_digit_subtraction from './double_digit_subtraction.json';
+import double_digit_multiplication from './double_digit_multiplication.json';
+import double_digit_division from './double_digit_division.json';
+import single_digit_mixed from './single_digit_mixed.json';
+import double_digit_mixed from './double_digit_mixed.json';
 import text_length from './text_length.json';
 import p2d_best30_ayame from './p2d_best30_ayame.json';
 import p2d_best31to60_ayame from './p2d_best31to60_ayame.json';
@@ -23,6 +32,51 @@ export const quizData = {
   brand2generic_diabetes: brand2generic_diabetes as Quiz[],
   antibiotics: antibiotics as Quiz[],
   simple_math: simple_math.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  single_digit_subtraction: single_digit_subtraction.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  single_digit_multiplication: single_digit_multiplication.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  single_digit_division: single_digit_division.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  double_digit_addition: double_digit_addition.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  double_digit_subtraction: double_digit_subtraction.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  double_digit_multiplication: double_digit_multiplication.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  double_digit_division: double_digit_division.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  single_digit_mixed: single_digit_mixed.map(quiz => ({
+    question: quiz.question,
+    correct: String(quiz.correct),
+    choices: quiz.choices.map(choice => String(choice))
+  })) as Quiz[],
+  double_digit_mixed: double_digit_mixed.map(quiz => ({
     question: quiz.question,
     correct: String(quiz.correct),
     choices: quiz.choices.map(choice => String(choice))

--- a/src/data/single_digit_division.json
+++ b/src/data/single_digit_division.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "1 ÷ 1 =",
+    "correct": 1,
+    "choices": [
+      8,
+      -7,
+      4,
+      1
+    ]
+  },
+  {
+    "question": "2 ÷ 1 =",
+    "correct": 2,
+    "choices": [
+      6,
+      -6,
+      2,
+      -2
+    ]
+  },
+  {
+    "question": "3 ÷ 1 =",
+    "correct": 3,
+    "choices": [
+      -5,
+      -3,
+      8,
+      3
+    ]
+  },
+  {
+    "question": "4 ÷ 1 =",
+    "correct": 4,
+    "choices": [
+      4,
+      -3,
+      -6,
+      3
+    ]
+  },
+  {
+    "question": "5 ÷ 1 =",
+    "correct": 5,
+    "choices": [
+      8,
+      5,
+      7,
+      9
+    ]
+  },
+  {
+    "question": "6 ÷ 1 =",
+    "correct": 6,
+    "choices": [
+      6,
+      9,
+      0,
+      -1
+    ]
+  },
+  {
+    "question": "7 ÷ 1 =",
+    "correct": 7,
+    "choices": [
+      -8,
+      -1,
+      2,
+      7
+    ]
+  },
+  {
+    "question": "8 ÷ 1 =",
+    "correct": 8,
+    "choices": [
+      8,
+      4,
+      -8,
+      -7
+    ]
+  },
+  {
+    "question": "9 ÷ 1 =",
+    "correct": 9,
+    "choices": [
+      9,
+      3,
+      0,
+      -2
+    ]
+  },
+  {
+    "question": "2 ÷ 2 =",
+    "correct": 1,
+    "choices": [
+      1,
+      -6,
+      -4,
+      -2
+    ]
+  },
+  {
+    "question": "4 ÷ 2 =",
+    "correct": 2,
+    "choices": [
+      -1,
+      2,
+      5,
+      -2
+    ]
+  },
+  {
+    "question": "6 ÷ 2 =",
+    "correct": 3,
+    "choices": [
+      3,
+      -8,
+      -2,
+      8
+    ]
+  },
+  {
+    "question": "8 ÷ 2 =",
+    "correct": 4,
+    "choices": [
+      -2,
+      9,
+      0,
+      4
+    ]
+  },
+  {
+    "question": "10 ÷ 2 =",
+    "correct": 5,
+    "choices": [
+      6,
+      4,
+      -6,
+      5
+    ]
+  },
+  {
+    "question": "12 ÷ 2 =",
+    "correct": 6,
+    "choices": [
+      -5,
+      -6,
+      6,
+      7
+    ]
+  },
+  {
+    "question": "14 ÷ 2 =",
+    "correct": 7,
+    "choices": [
+      7,
+      -2,
+      -5,
+      5
+    ]
+  },
+  {
+    "question": "16 ÷ 2 =",
+    "correct": 8,
+    "choices": [
+      8,
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "question": "18 ÷ 2 =",
+    "correct": 9,
+    "choices": [
+      -8,
+      3,
+      9,
+      8
+    ]
+  },
+  {
+    "question": "3 ÷ 3 =",
+    "correct": 1,
+    "choices": [
+      2,
+      1,
+      -7,
+      -9
+    ]
+  },
+  {
+    "question": "6 ÷ 3 =",
+    "correct": 2,
+    "choices": [
+      6,
+      2,
+      -5,
+      5
+    ]
+  },
+  {
+    "question": "9 ÷ 3 =",
+    "correct": 3,
+    "choices": [
+      -5,
+      4,
+      -3,
+      3
+    ]
+  },
+  {
+    "question": "12 ÷ 3 =",
+    "correct": 4,
+    "choices": [
+      -2,
+      1,
+      4,
+      3
+    ]
+  },
+  {
+    "question": "15 ÷ 3 =",
+    "correct": 5,
+    "choices": [
+      -8,
+      -7,
+      -5,
+      5
+    ]
+  },
+  {
+    "question": "18 ÷ 3 =",
+    "correct": 6,
+    "choices": [
+      -7,
+      1,
+      6,
+      9
+    ]
+  },
+  {
+    "question": "21 ÷ 3 =",
+    "correct": 7,
+    "choices": [
+      3,
+      7,
+      -5,
+      -9
+    ]
+  },
+  {
+    "question": "24 ÷ 3 =",
+    "correct": 8,
+    "choices": [
+      2,
+      -9,
+      7,
+      8
+    ]
+  },
+  {
+    "question": "27 ÷ 3 =",
+    "correct": 9,
+    "choices": [
+      -9,
+      9,
+      1,
+      7
+    ]
+  },
+  {
+    "question": "4 ÷ 4 =",
+    "correct": 1,
+    "choices": [
+      -6,
+      -9,
+      1,
+      -7
+    ]
+  },
+  {
+    "question": "8 ÷ 4 =",
+    "correct": 2,
+    "choices": [
+      2,
+      4,
+      -5,
+      -7
+    ]
+  },
+  {
+    "question": "12 ÷ 4 =",
+    "correct": 3,
+    "choices": [
+      -4,
+      3,
+      -8,
+      -5
+    ]
+  },
+  {
+    "question": "16 ÷ 4 =",
+    "correct": 4,
+    "choices": [
+      -4,
+      1,
+      -2,
+      4
+    ]
+  },
+  {
+    "question": "20 ÷ 4 =",
+    "correct": 5,
+    "choices": [
+      8,
+      4,
+      6,
+      5
+    ]
+  },
+  {
+    "question": "24 ÷ 4 =",
+    "correct": 6,
+    "choices": [
+      -3,
+      6,
+      -1,
+      8
+    ]
+  },
+  {
+    "question": "28 ÷ 4 =",
+    "correct": 7,
+    "choices": [
+      0,
+      -5,
+      -1,
+      7
+    ]
+  },
+  {
+    "question": "32 ÷ 4 =",
+    "correct": 8,
+    "choices": [
+      -5,
+      -4,
+      8,
+      2
+    ]
+  },
+  {
+    "question": "36 ÷ 4 =",
+    "correct": 9,
+    "choices": [
+      2,
+      -5,
+      9,
+      3
+    ]
+  },
+  {
+    "question": "5 ÷ 5 =",
+    "correct": 1,
+    "choices": [
+      -5,
+      4,
+      1,
+      3
+    ]
+  },
+  {
+    "question": "10 ÷ 5 =",
+    "correct": 2,
+    "choices": [
+      5,
+      2,
+      8,
+      1
+    ]
+  },
+  {
+    "question": "15 ÷ 5 =",
+    "correct": 3,
+    "choices": [
+      -6,
+      9,
+      3,
+      -1
+    ]
+  },
+  {
+    "question": "20 ÷ 5 =",
+    "correct": 4,
+    "choices": [
+      6,
+      4,
+      -1,
+      -6
+    ]
+  },
+  {
+    "question": "25 ÷ 5 =",
+    "correct": 5,
+    "choices": [
+      -3,
+      -9,
+      5,
+      7
+    ]
+  },
+  {
+    "question": "30 ÷ 5 =",
+    "correct": 6,
+    "choices": [
+      0,
+      6,
+      -3,
+      7
+    ]
+  },
+  {
+    "question": "35 ÷ 5 =",
+    "correct": 7,
+    "choices": [
+      8,
+      7,
+      -3,
+      -2
+    ]
+  },
+  {
+    "question": "40 ÷ 5 =",
+    "correct": 8,
+    "choices": [
+      8,
+      3,
+      -9,
+      1
+    ]
+  },
+  {
+    "question": "45 ÷ 5 =",
+    "correct": 9,
+    "choices": [
+      -3,
+      -6,
+      9,
+      2
+    ]
+  },
+  {
+    "question": "6 ÷ 6 =",
+    "correct": 1,
+    "choices": [
+      6,
+      1,
+      -7,
+      -2
+    ]
+  },
+  {
+    "question": "12 ÷ 6 =",
+    "correct": 2,
+    "choices": [
+      -2,
+      2,
+      9,
+      -4
+    ]
+  },
+  {
+    "question": "18 ÷ 6 =",
+    "correct": 3,
+    "choices": [
+      -8,
+      -2,
+      -7,
+      3
+    ]
+  },
+  {
+    "question": "24 ÷ 6 =",
+    "correct": 4,
+    "choices": [
+      7,
+      4,
+      8,
+      5
+    ]
+  },
+  {
+    "question": "30 ÷ 6 =",
+    "correct": 5,
+    "choices": [
+      5,
+      6,
+      -8,
+      -6
+    ]
+  },
+  {
+    "question": "36 ÷ 6 =",
+    "correct": 6,
+    "choices": [
+      7,
+      -6,
+      1,
+      6
+    ]
+  },
+  {
+    "question": "42 ÷ 6 =",
+    "correct": 7,
+    "choices": [
+      5,
+      4,
+      3,
+      7
+    ]
+  },
+  {
+    "question": "48 ÷ 6 =",
+    "correct": 8,
+    "choices": [
+      1,
+      8,
+      6,
+      0
+    ]
+  },
+  {
+    "question": "54 ÷ 6 =",
+    "correct": 9,
+    "choices": [
+      -6,
+      9,
+      2,
+      -5
+    ]
+  },
+  {
+    "question": "7 ÷ 7 =",
+    "correct": 1,
+    "choices": [
+      1,
+      6,
+      5,
+      -1
+    ]
+  },
+  {
+    "question": "14 ÷ 7 =",
+    "correct": 2,
+    "choices": [
+      -9,
+      2,
+      7,
+      -8
+    ]
+  },
+  {
+    "question": "21 ÷ 7 =",
+    "correct": 3,
+    "choices": [
+      -5,
+      3,
+      9,
+      6
+    ]
+  },
+  {
+    "question": "28 ÷ 7 =",
+    "correct": 4,
+    "choices": [
+      5,
+      4,
+      -8,
+      -4
+    ]
+  },
+  {
+    "question": "35 ÷ 7 =",
+    "correct": 5,
+    "choices": [
+      -1,
+      5,
+      -6,
+      8
+    ]
+  },
+  {
+    "question": "42 ÷ 7 =",
+    "correct": 6,
+    "choices": [
+      -7,
+      6,
+      2,
+      1
+    ]
+  },
+  {
+    "question": "49 ÷ 7 =",
+    "correct": 7,
+    "choices": [
+      0,
+      5,
+      7,
+      4
+    ]
+  },
+  {
+    "question": "56 ÷ 7 =",
+    "correct": 8,
+    "choices": [
+      -7,
+      0,
+      -6,
+      8
+    ]
+  },
+  {
+    "question": "63 ÷ 7 =",
+    "correct": 9,
+    "choices": [
+      9,
+      3,
+      8,
+      1
+    ]
+  },
+  {
+    "question": "8 ÷ 8 =",
+    "correct": 1,
+    "choices": [
+      1,
+      6,
+      -4,
+      5
+    ]
+  },
+  {
+    "question": "16 ÷ 8 =",
+    "correct": 2,
+    "choices": [
+      -5,
+      1,
+      2,
+      -9
+    ]
+  },
+  {
+    "question": "24 ÷ 8 =",
+    "correct": 3,
+    "choices": [
+      -3,
+      3,
+      4,
+      7
+    ]
+  },
+  {
+    "question": "32 ÷ 8 =",
+    "correct": 4,
+    "choices": [
+      -6,
+      4,
+      -9,
+      8
+    ]
+  },
+  {
+    "question": "40 ÷ 8 =",
+    "correct": 5,
+    "choices": [
+      0,
+      -9,
+      5,
+      7
+    ]
+  },
+  {
+    "question": "48 ÷ 8 =",
+    "correct": 6,
+    "choices": [
+      8,
+      -9,
+      6,
+      5
+    ]
+  },
+  {
+    "question": "56 ÷ 8 =",
+    "correct": 7,
+    "choices": [
+      5,
+      7,
+      9,
+      6
+    ]
+  },
+  {
+    "question": "64 ÷ 8 =",
+    "correct": 8,
+    "choices": [
+      0,
+      1,
+      8,
+      9
+    ]
+  },
+  {
+    "question": "72 ÷ 8 =",
+    "correct": 9,
+    "choices": [
+      9,
+      3,
+      2,
+      -9
+    ]
+  },
+  {
+    "question": "9 ÷ 9 =",
+    "correct": 1,
+    "choices": [
+      5,
+      -8,
+      1,
+      -4
+    ]
+  },
+  {
+    "question": "18 ÷ 9 =",
+    "correct": 2,
+    "choices": [
+      9,
+      2,
+      -9,
+      3
+    ]
+  },
+  {
+    "question": "27 ÷ 9 =",
+    "correct": 3,
+    "choices": [
+      3,
+      -2,
+      -1,
+      -9
+    ]
+  },
+  {
+    "question": "36 ÷ 9 =",
+    "correct": 4,
+    "choices": [
+      -3,
+      4,
+      -6,
+      9
+    ]
+  },
+  {
+    "question": "45 ÷ 9 =",
+    "correct": 5,
+    "choices": [
+      7,
+      5,
+      -4,
+      -8
+    ]
+  },
+  {
+    "question": "54 ÷ 9 =",
+    "correct": 6,
+    "choices": [
+      -3,
+      6,
+      4,
+      5
+    ]
+  },
+  {
+    "question": "63 ÷ 9 =",
+    "correct": 7,
+    "choices": [
+      -8,
+      7,
+      -7,
+      9
+    ]
+  },
+  {
+    "question": "72 ÷ 9 =",
+    "correct": 8,
+    "choices": [
+      -8,
+      5,
+      1,
+      8
+    ]
+  },
+  {
+    "question": "81 ÷ 9 =",
+    "correct": 9,
+    "choices": [
+      5,
+      9,
+      -8,
+      -6
+    ]
+  }
+]

--- a/src/data/single_digit_mixed.json
+++ b/src/data/single_digit_mixed.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "8 x 5 =",
+    "correct": 40,
+    "choices": [
+      -60,
+      40,
+      33,
+      -58
+    ]
+  },
+  {
+    "question": "20 ÷ 2 =",
+    "correct": 5,
+    "choices": [
+      4,
+      -2,
+      5,
+      -4
+    ]
+  },
+  {
+    "question": "1 x 3 =",
+    "correct": 3,
+    "choices": [
+      68,
+      3,
+      0,
+      -51
+    ]
+  },
+  {
+    "question": "8 + 1 =",
+    "correct": 9,
+    "choices": [
+      9,
+      -20,
+      -19,
+      -18
+    ]
+  },
+  {
+    "question": "24 ÷ 7 =",
+    "correct": 3,
+    "choices": [
+      6,
+      3,
+      4,
+      1
+    ]
+  },
+  {
+    "question": "30 ÷ 9 =",
+    "correct": 6,
+    "choices": [
+      7,
+      6,
+      -3,
+      4
+    ]
+  },
+  {
+    "question": "4 + 5 =",
+    "correct": 9,
+    "choices": [
+      9,
+      -12,
+      -19,
+      19
+    ]
+  },
+  {
+    "question": "7 - 9 =",
+    "correct": -2,
+    "choices": [
+      7,
+      -6,
+      -5,
+      -2
+    ]
+  },
+  {
+    "question": "7 - 3 =",
+    "correct": 4,
+    "choices": [
+      5,
+      -1,
+      6,
+      4
+    ]
+  },
+  {
+    "question": "8 - 3 =",
+    "correct": 5,
+    "choices": [
+      5,
+      -2,
+      1,
+      -4
+    ]
+  },
+  {
+    "question": "6 - 7 =",
+    "correct": -1,
+    "choices": [
+      -1,
+      9,
+      -6,
+      -5
+    ]
+  },
+  {
+    "question": "24 ÷ 7 =",
+    "correct": 6,
+    "choices": [
+      6,
+      -3,
+      7,
+      -8
+    ]
+  },
+  {
+    "question": "9 x 3 =",
+    "correct": 27,
+    "choices": [
+      33,
+      -36,
+      27,
+      -65
+    ]
+  },
+  {
+    "question": "2 x 4 =",
+    "correct": 8,
+    "choices": [
+      -77,
+      8,
+      79,
+      18
+    ]
+  },
+  {
+    "question": "6 + 6 =",
+    "correct": 12,
+    "choices": [
+      12,
+      -10,
+      7,
+      -9
+    ]
+  },
+  {
+    "question": "6 x 4 =",
+    "correct": 24,
+    "choices": [
+      24,
+      -27,
+      2,
+      15
+    ]
+  },
+  {
+    "question": "24 ÷ 8 =",
+    "correct": 4,
+    "choices": [
+      -2,
+      4,
+      -7,
+      -8
+    ]
+  },
+  {
+    "question": "1 + 8 =",
+    "correct": 9,
+    "choices": [
+      -4,
+      -13,
+      9,
+      -14
+    ]
+  },
+  {
+    "question": "6 x 5 =",
+    "correct": 30,
+    "choices": [
+      -37,
+      30,
+      55,
+      -77
+    ]
+  },
+  {
+    "question": "2 + 8 =",
+    "correct": 10,
+    "choices": [
+      14,
+      10,
+      -1,
+      3
+    ]
+  },
+  {
+    "question": "5 - 4 =",
+    "correct": 1,
+    "choices": [
+      7,
+      4,
+      1,
+      -6
+    ]
+  },
+  {
+    "question": "6 x 8 =",
+    "correct": 48,
+    "choices": [
+      69,
+      48,
+      37,
+      -25
+    ]
+  },
+  {
+    "question": "4 + 6 =",
+    "correct": 10,
+    "choices": [
+      10,
+      5,
+      -5,
+      -16
+    ]
+  },
+  {
+    "question": "9 x 8 =",
+    "correct": 72,
+    "choices": [
+      -49,
+      -48,
+      1,
+      72
+    ]
+  },
+  {
+    "question": "36 ÷ 4 =",
+    "correct": 4,
+    "choices": [
+      -6,
+      2,
+      -9,
+      4
+    ]
+  },
+  {
+    "question": "2 + 4 =",
+    "correct": 6,
+    "choices": [
+      -6,
+      -15,
+      -7,
+      6
+    ]
+  },
+  {
+    "question": "48 ÷ 2 =",
+    "correct": 8,
+    "choices": [
+      -2,
+      2,
+      8,
+      1
+    ]
+  },
+  {
+    "question": "8 - 7 =",
+    "correct": 1,
+    "choices": [
+      7,
+      -8,
+      6,
+      1
+    ]
+  },
+  {
+    "question": "1 + 3 =",
+    "correct": 4,
+    "choices": [
+      -15,
+      4,
+      -13,
+      -14
+    ]
+  },
+  {
+    "question": "2 x 3 =",
+    "correct": 6,
+    "choices": [
+      2,
+      77,
+      -77,
+      6
+    ]
+  },
+  {
+    "question": "6 - 9 =",
+    "correct": -3,
+    "choices": [
+      7,
+      6,
+      -3,
+      -10
+    ]
+  },
+  {
+    "question": "8 + 4 =",
+    "correct": 12,
+    "choices": [
+      13,
+      9,
+      -1,
+      12
+    ]
+  },
+  {
+    "question": "2 - 9 =",
+    "correct": -7,
+    "choices": [
+      -7,
+      8,
+      3,
+      9
+    ]
+  },
+  {
+    "question": "1 x 3 =",
+    "correct": 3,
+    "choices": [
+      76,
+      -45,
+      40,
+      3
+    ]
+  },
+  {
+    "question": "2 + 4 =",
+    "correct": 6,
+    "choices": [
+      6,
+      15,
+      3,
+      -17
+    ]
+  },
+  {
+    "question": "4 + 6 =",
+    "correct": 10,
+    "choices": [
+      -12,
+      -15,
+      11,
+      10
+    ]
+  },
+  {
+    "question": "9 x 6 =",
+    "correct": 54,
+    "choices": [
+      54,
+      8,
+      30,
+      -53
+    ]
+  },
+  {
+    "question": "7 + 5 =",
+    "correct": 12,
+    "choices": [
+      -10,
+      -6,
+      12,
+      -7
+    ]
+  },
+  {
+    "question": "6 ÷ 9 =",
+    "correct": 6,
+    "choices": [
+      -7,
+      -1,
+      5,
+      6
+    ]
+  },
+  {
+    "question": "6 ÷ 3 =",
+    "correct": 2,
+    "choices": [
+      -4,
+      3,
+      2,
+      4
+    ]
+  },
+  {
+    "question": "2 ÷ 8 =",
+    "correct": 2,
+    "choices": [
+      7,
+      -7,
+      2,
+      -8
+    ]
+  },
+  {
+    "question": "6 + 6 =",
+    "correct": 12,
+    "choices": [
+      12,
+      4,
+      -12,
+      -17
+    ]
+  },
+  {
+    "question": "6 ÷ 8 =",
+    "correct": 2,
+    "choices": [
+      2,
+      -6,
+      -5,
+      -7
+    ]
+  },
+  {
+    "question": "8 + 1 =",
+    "correct": 9,
+    "choices": [
+      -3,
+      19,
+      -1,
+      9
+    ]
+  },
+  {
+    "question": "3 - 5 =",
+    "correct": -2,
+    "choices": [
+      -10,
+      10,
+      9,
+      -2
+    ]
+  },
+  {
+    "question": "1 + 6 =",
+    "correct": 7,
+    "choices": [
+      10,
+      7,
+      -18,
+      4
+    ]
+  },
+  {
+    "question": "5 - 9 =",
+    "correct": -4,
+    "choices": [
+      -4,
+      10,
+      4,
+      0
+    ]
+  },
+  {
+    "question": "72 ÷ 8 =",
+    "correct": 9,
+    "choices": [
+      -2,
+      7,
+      9,
+      2
+    ]
+  },
+  {
+    "question": "1 - 4 =",
+    "correct": -3,
+    "choices": [
+      3,
+      -3,
+      -4,
+      8
+    ]
+  },
+  {
+    "question": "7 x 7 =",
+    "correct": 49,
+    "choices": [
+      49,
+      -33,
+      -70,
+      -40
+    ]
+  },
+  {
+    "question": "2 - 1 =",
+    "correct": 1,
+    "choices": [
+      -6,
+      1,
+      -2,
+      0
+    ]
+  },
+  {
+    "question": "3 + 4 =",
+    "correct": 7,
+    "choices": [
+      16,
+      -6,
+      7,
+      9
+    ]
+  },
+  {
+    "question": "35 ÷ 9 =",
+    "correct": 7,
+    "choices": [
+      7,
+      1,
+      -7,
+      -4
+    ]
+  },
+  {
+    "question": "32 ÷ 3 =",
+    "correct": 4,
+    "choices": [
+      6,
+      9,
+      -5,
+      4
+    ]
+  },
+  {
+    "question": "9 - 7 =",
+    "correct": 2,
+    "choices": [
+      7,
+      10,
+      8,
+      2
+    ]
+  },
+  {
+    "question": "8 + 4 =",
+    "correct": 12,
+    "choices": [
+      15,
+      -3,
+      12,
+      8
+    ]
+  },
+  {
+    "question": "30 ÷ 1 =",
+    "correct": 5,
+    "choices": [
+      -5,
+      -1,
+      9,
+      5
+    ]
+  },
+  {
+    "question": "8 x 1 =",
+    "correct": 8,
+    "choices": [
+      19,
+      -41,
+      3,
+      8
+    ]
+  },
+  {
+    "question": "5 x 2 =",
+    "correct": 10,
+    "choices": [
+      -61,
+      -71,
+      10,
+      68
+    ]
+  },
+  {
+    "question": "8 + 7 =",
+    "correct": 15,
+    "choices": [
+      14,
+      -7,
+      15,
+      -8
+    ]
+  },
+  {
+    "question": "3 + 3 =",
+    "correct": 6,
+    "choices": [
+      -1,
+      6,
+      11,
+      -13
+    ]
+  },
+  {
+    "question": "5 + 6 =",
+    "correct": 11,
+    "choices": [
+      4,
+      -9,
+      -1,
+      11
+    ]
+  },
+  {
+    "question": "5 x 9 =",
+    "correct": 45,
+    "choices": [
+      -31,
+      -19,
+      -30,
+      45
+    ]
+  },
+  {
+    "question": "4 ÷ 1 =",
+    "correct": 4,
+    "choices": [
+      4,
+      6,
+      0,
+      3
+    ]
+  },
+  {
+    "question": "7 x 4 =",
+    "correct": 28,
+    "choices": [
+      -68,
+      9,
+      28,
+      -2
+    ]
+  },
+  {
+    "question": "1 x 4 =",
+    "correct": 4,
+    "choices": [
+      -68,
+      74,
+      4,
+      -60
+    ]
+  },
+  {
+    "question": "6 + 6 =",
+    "correct": 12,
+    "choices": [
+      12,
+      2,
+      -19,
+      1
+    ]
+  },
+  {
+    "question": "4 x 3 =",
+    "correct": 12,
+    "choices": [
+      12,
+      2,
+      -15,
+      -65
+    ]
+  },
+  {
+    "question": "4 + 9 =",
+    "correct": 13,
+    "choices": [
+      12,
+      13,
+      2,
+      -17
+    ]
+  },
+  {
+    "question": "8 ÷ 7 =",
+    "correct": 4,
+    "choices": [
+      2,
+      4,
+      -2,
+      -3
+    ]
+  },
+  {
+    "question": "9 - 1 =",
+    "correct": 8,
+    "choices": [
+      8,
+      -4,
+      -3,
+      -2
+    ]
+  },
+  {
+    "question": "45 ÷ 5 =",
+    "correct": 9,
+    "choices": [
+      5,
+      -7,
+      4,
+      9
+    ]
+  },
+  {
+    "question": "5 + 5 =",
+    "correct": 10,
+    "choices": [
+      10,
+      -10,
+      -13,
+      14
+    ]
+  },
+  {
+    "question": "7 - 9 =",
+    "correct": -2,
+    "choices": [
+      -1,
+      1,
+      7,
+      -2
+    ]
+  },
+  {
+    "question": "9 x 2 =",
+    "correct": 18,
+    "choices": [
+      27,
+      6,
+      18,
+      -68
+    ]
+  },
+  {
+    "question": "7 x 4 =",
+    "correct": 28,
+    "choices": [
+      -12,
+      28,
+      -29,
+      27
+    ]
+  },
+  {
+    "question": "8 ÷ 3 =",
+    "correct": 1,
+    "choices": [
+      -1,
+      1,
+      3,
+      -8
+    ]
+  },
+  {
+    "question": "4 + 7 =",
+    "correct": 11,
+    "choices": [
+      -16,
+      -19,
+      -6,
+      11
+    ]
+  },
+  {
+    "question": "6 ÷ 2 =",
+    "correct": 3,
+    "choices": [
+      3,
+      -2,
+      8,
+      -4
+    ]
+  },
+  {
+    "question": "5 x 3 =",
+    "correct": 15,
+    "choices": [
+      -25,
+      -57,
+      15,
+      -64
+    ]
+  },
+  {
+    "question": "6 - 8 =",
+    "correct": -2,
+    "choices": [
+      1,
+      7,
+      -2,
+      -8
+    ]
+  }
+]

--- a/src/data/single_digit_multiplication.json
+++ b/src/data/single_digit_multiplication.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "1 x 1 =",
+    "correct": 1,
+    "choices": [
+      -33,
+      55,
+      38,
+      1
+    ]
+  },
+  {
+    "question": "1 x 2 =",
+    "correct": 2,
+    "choices": [
+      4,
+      -35,
+      -57,
+      2
+    ]
+  },
+  {
+    "question": "1 x 3 =",
+    "correct": 3,
+    "choices": [
+      -64,
+      3,
+      -33,
+      9
+    ]
+  },
+  {
+    "question": "1 x 4 =",
+    "correct": 4,
+    "choices": [
+      78,
+      -36,
+      4,
+      66
+    ]
+  },
+  {
+    "question": "1 x 5 =",
+    "correct": 5,
+    "choices": [
+      5,
+      3,
+      0,
+      42
+    ]
+  },
+  {
+    "question": "1 x 6 =",
+    "correct": 6,
+    "choices": [
+      29,
+      73,
+      6,
+      15
+    ]
+  },
+  {
+    "question": "1 x 7 =",
+    "correct": 7,
+    "choices": [
+      -58,
+      0,
+      59,
+      7
+    ]
+  },
+  {
+    "question": "1 x 8 =",
+    "correct": 8,
+    "choices": [
+      8,
+      -26,
+      36,
+      7
+    ]
+  },
+  {
+    "question": "1 x 9 =",
+    "correct": 9,
+    "choices": [
+      -38,
+      57,
+      -35,
+      9
+    ]
+  },
+  {
+    "question": "2 x 1 =",
+    "correct": 2,
+    "choices": [
+      55,
+      -65,
+      -22,
+      2
+    ]
+  },
+  {
+    "question": "2 x 2 =",
+    "correct": 4,
+    "choices": [
+      4,
+      -21,
+      55,
+      -53
+    ]
+  },
+  {
+    "question": "2 x 3 =",
+    "correct": 6,
+    "choices": [
+      -30,
+      19,
+      6,
+      69
+    ]
+  },
+  {
+    "question": "2 x 4 =",
+    "correct": 8,
+    "choices": [
+      -56,
+      -51,
+      8,
+      -9
+    ]
+  },
+  {
+    "question": "2 x 5 =",
+    "correct": 10,
+    "choices": [
+      11,
+      -51,
+      10,
+      8
+    ]
+  },
+  {
+    "question": "2 x 6 =",
+    "correct": 12,
+    "choices": [
+      -31,
+      -12,
+      -32,
+      12
+    ]
+  },
+  {
+    "question": "2 x 7 =",
+    "correct": 14,
+    "choices": [
+      -81,
+      14,
+      -65,
+      12
+    ]
+  },
+  {
+    "question": "2 x 8 =",
+    "correct": 16,
+    "choices": [
+      16,
+      -34,
+      -45,
+      46
+    ]
+  },
+  {
+    "question": "2 x 9 =",
+    "correct": 18,
+    "choices": [
+      72,
+      -59,
+      33,
+      18
+    ]
+  },
+  {
+    "question": "3 x 1 =",
+    "correct": 3,
+    "choices": [
+      -63,
+      -20,
+      3,
+      -30
+    ]
+  },
+  {
+    "question": "3 x 2 =",
+    "correct": 6,
+    "choices": [
+      2,
+      6,
+      37,
+      -78
+    ]
+  },
+  {
+    "question": "3 x 3 =",
+    "correct": 9,
+    "choices": [
+      -53,
+      9,
+      -50,
+      -27
+    ]
+  },
+  {
+    "question": "3 x 4 =",
+    "correct": 12,
+    "choices": [
+      33,
+      -81,
+      12,
+      -17
+    ]
+  },
+  {
+    "question": "3 x 5 =",
+    "correct": 15,
+    "choices": [
+      -2,
+      15,
+      -63,
+      64
+    ]
+  },
+  {
+    "question": "3 x 6 =",
+    "correct": 18,
+    "choices": [
+      13,
+      18,
+      68,
+      45
+    ]
+  },
+  {
+    "question": "3 x 7 =",
+    "correct": 21,
+    "choices": [
+      21,
+      -4,
+      -37,
+      53
+    ]
+  },
+  {
+    "question": "3 x 8 =",
+    "correct": 24,
+    "choices": [
+      -20,
+      24,
+      54,
+      33
+    ]
+  },
+  {
+    "question": "3 x 9 =",
+    "correct": 27,
+    "choices": [
+      -64,
+      27,
+      -21,
+      40
+    ]
+  },
+  {
+    "question": "4 x 1 =",
+    "correct": 4,
+    "choices": [
+      4,
+      -13,
+      11,
+      -64
+    ]
+  },
+  {
+    "question": "4 x 2 =",
+    "correct": 8,
+    "choices": [
+      8,
+      -67,
+      0,
+      -47
+    ]
+  },
+  {
+    "question": "4 x 3 =",
+    "correct": 12,
+    "choices": [
+      12,
+      17,
+      -7,
+      -75
+    ]
+  },
+  {
+    "question": "4 x 4 =",
+    "correct": 16,
+    "choices": [
+      68,
+      -74,
+      16,
+      4
+    ]
+  },
+  {
+    "question": "4 x 5 =",
+    "correct": 20,
+    "choices": [
+      20,
+      40,
+      66,
+      -29
+    ]
+  },
+  {
+    "question": "4 x 6 =",
+    "correct": 24,
+    "choices": [
+      30,
+      24,
+      28,
+      9
+    ]
+  },
+  {
+    "question": "4 x 7 =",
+    "correct": 28,
+    "choices": [
+      -34,
+      28,
+      35,
+      23
+    ]
+  },
+  {
+    "question": "4 x 8 =",
+    "correct": 32,
+    "choices": [
+      32,
+      -8,
+      81,
+      8
+    ]
+  },
+  {
+    "question": "4 x 9 =",
+    "correct": 36,
+    "choices": [
+      5,
+      36,
+      -22,
+      -53
+    ]
+  },
+  {
+    "question": "5 x 1 =",
+    "correct": 5,
+    "choices": [
+      -48,
+      5,
+      40,
+      -20
+    ]
+  },
+  {
+    "question": "5 x 2 =",
+    "correct": 10,
+    "choices": [
+      17,
+      -8,
+      10,
+      3
+    ]
+  },
+  {
+    "question": "5 x 3 =",
+    "correct": 15,
+    "choices": [
+      15,
+      -21,
+      -66,
+      10
+    ]
+  },
+  {
+    "question": "5 x 4 =",
+    "correct": 20,
+    "choices": [
+      6,
+      -67,
+      20,
+      43
+    ]
+  },
+  {
+    "question": "5 x 5 =",
+    "correct": 25,
+    "choices": [
+      25,
+      1,
+      60,
+      -49
+    ]
+  },
+  {
+    "question": "5 x 6 =",
+    "correct": 30,
+    "choices": [
+      -56,
+      30,
+      18,
+      81
+    ]
+  },
+  {
+    "question": "5 x 7 =",
+    "correct": 35,
+    "choices": [
+      55,
+      35,
+      14,
+      -47
+    ]
+  },
+  {
+    "question": "5 x 8 =",
+    "correct": 40,
+    "choices": [
+      40,
+      45,
+      61,
+      79
+    ]
+  },
+  {
+    "question": "5 x 9 =",
+    "correct": 45,
+    "choices": [
+      65,
+      45,
+      -24,
+      -9
+    ]
+  },
+  {
+    "question": "6 x 1 =",
+    "correct": 6,
+    "choices": [
+      -57,
+      -37,
+      6,
+      -31
+    ]
+  },
+  {
+    "question": "6 x 2 =",
+    "correct": 12,
+    "choices": [
+      12,
+      30,
+      -31,
+      -69
+    ]
+  },
+  {
+    "question": "6 x 3 =",
+    "correct": 18,
+    "choices": [
+      54,
+      17,
+      72,
+      18
+    ]
+  },
+  {
+    "question": "6 x 4 =",
+    "correct": 24,
+    "choices": [
+      -12,
+      24,
+      49,
+      -34
+    ]
+  },
+  {
+    "question": "6 x 5 =",
+    "correct": 30,
+    "choices": [
+      -47,
+      -71,
+      16,
+      30
+    ]
+  },
+  {
+    "question": "6 x 6 =",
+    "correct": 36,
+    "choices": [
+      55,
+      -28,
+      36,
+      77
+    ]
+  },
+  {
+    "question": "6 x 7 =",
+    "correct": 42,
+    "choices": [
+      -17,
+      -43,
+      29,
+      42
+    ]
+  },
+  {
+    "question": "6 x 8 =",
+    "correct": 48,
+    "choices": [
+      48,
+      -33,
+      -28,
+      -1
+    ]
+  },
+  {
+    "question": "6 x 9 =",
+    "correct": 54,
+    "choices": [
+      25,
+      54,
+      -43,
+      48
+    ]
+  },
+  {
+    "question": "7 x 1 =",
+    "correct": 7,
+    "choices": [
+      60,
+      21,
+      7,
+      -4
+    ]
+  },
+  {
+    "question": "7 x 2 =",
+    "correct": 14,
+    "choices": [
+      14,
+      -68,
+      -69,
+      -75
+    ]
+  },
+  {
+    "question": "7 x 3 =",
+    "correct": 21,
+    "choices": [
+      -59,
+      21,
+      -50,
+      76
+    ]
+  },
+  {
+    "question": "7 x 4 =",
+    "correct": 28,
+    "choices": [
+      62,
+      33,
+      28,
+      3
+    ]
+  },
+  {
+    "question": "7 x 5 =",
+    "correct": 35,
+    "choices": [
+      -53,
+      53,
+      35,
+      -52
+    ]
+  },
+  {
+    "question": "7 x 6 =",
+    "correct": 42,
+    "choices": [
+      67,
+      -64,
+      42,
+      39
+    ]
+  },
+  {
+    "question": "7 x 7 =",
+    "correct": 49,
+    "choices": [
+      68,
+      -43,
+      11,
+      49
+    ]
+  },
+  {
+    "question": "7 x 8 =",
+    "correct": 56,
+    "choices": [
+      56,
+      31,
+      -18,
+      81
+    ]
+  },
+  {
+    "question": "7 x 9 =",
+    "correct": 63,
+    "choices": [
+      23,
+      63,
+      -81,
+      41
+    ]
+  },
+  {
+    "question": "8 x 1 =",
+    "correct": 8,
+    "choices": [
+      -71,
+      8,
+      49,
+      -32
+    ]
+  },
+  {
+    "question": "8 x 2 =",
+    "correct": 16,
+    "choices": [
+      -10,
+      -54,
+      -42,
+      16
+    ]
+  },
+  {
+    "question": "8 x 3 =",
+    "correct": 24,
+    "choices": [
+      -13,
+      -51,
+      24,
+      56
+    ]
+  },
+  {
+    "question": "8 x 4 =",
+    "correct": 32,
+    "choices": [
+      65,
+      32,
+      -33,
+      1
+    ]
+  },
+  {
+    "question": "8 x 5 =",
+    "correct": 40,
+    "choices": [
+      40,
+      24,
+      -58,
+      13
+    ]
+  },
+  {
+    "question": "8 x 6 =",
+    "correct": 48,
+    "choices": [
+      -70,
+      48,
+      -47,
+      -78
+    ]
+  },
+  {
+    "question": "8 x 7 =",
+    "correct": 56,
+    "choices": [
+      21,
+      -58,
+      44,
+      56
+    ]
+  },
+  {
+    "question": "8 x 8 =",
+    "correct": 64,
+    "choices": [
+      64,
+      49,
+      30,
+      45
+    ]
+  },
+  {
+    "question": "8 x 9 =",
+    "correct": 72,
+    "choices": [
+      -13,
+      12,
+      -33,
+      72
+    ]
+  },
+  {
+    "question": "9 x 1 =",
+    "correct": 9,
+    "choices": [
+      49,
+      -74,
+      9,
+      -29
+    ]
+  },
+  {
+    "question": "9 x 2 =",
+    "correct": 18,
+    "choices": [
+      -7,
+      -33,
+      -56,
+      18
+    ]
+  },
+  {
+    "question": "9 x 3 =",
+    "correct": 27,
+    "choices": [
+      47,
+      -6,
+      74,
+      27
+    ]
+  },
+  {
+    "question": "9 x 4 =",
+    "correct": 36,
+    "choices": [
+      -43,
+      30,
+      36,
+      -64
+    ]
+  },
+  {
+    "question": "9 x 5 =",
+    "correct": 45,
+    "choices": [
+      -12,
+      45,
+      -58,
+      47
+    ]
+  },
+  {
+    "question": "9 x 6 =",
+    "correct": 54,
+    "choices": [
+      -19,
+      54,
+      66,
+      -43
+    ]
+  },
+  {
+    "question": "9 x 7 =",
+    "correct": 63,
+    "choices": [
+      63,
+      -45,
+      2,
+      -60
+    ]
+  },
+  {
+    "question": "9 x 8 =",
+    "correct": 72,
+    "choices": [
+      69,
+      58,
+      -15,
+      72
+    ]
+  },
+  {
+    "question": "9 x 9 =",
+    "correct": 81,
+    "choices": [
+      -61,
+      -76,
+      27,
+      81
+    ]
+  }
+]

--- a/src/data/single_digit_subtraction.json
+++ b/src/data/single_digit_subtraction.json
@@ -1,0 +1,812 @@
+[
+  {
+    "question": "1 - 1 =",
+    "correct": 0,
+    "choices": [
+      0,
+      -1,
+      7,
+      5
+    ]
+  },
+  {
+    "question": "1 - 2 =",
+    "correct": -1,
+    "choices": [
+      -1,
+      -5,
+      2,
+      -2
+    ]
+  },
+  {
+    "question": "1 - 3 =",
+    "correct": -2,
+    "choices": [
+      -8,
+      -2,
+      5,
+      10
+    ]
+  },
+  {
+    "question": "1 - 4 =",
+    "correct": -3,
+    "choices": [
+      6,
+      10,
+      7,
+      -3
+    ]
+  },
+  {
+    "question": "1 - 5 =",
+    "correct": -4,
+    "choices": [
+      -3,
+      -4,
+      7,
+      -5
+    ]
+  },
+  {
+    "question": "1 - 6 =",
+    "correct": -5,
+    "choices": [
+      4,
+      -4,
+      -5,
+      -1
+    ]
+  },
+  {
+    "question": "1 - 7 =",
+    "correct": -6,
+    "choices": [
+      -7,
+      1,
+      -8,
+      -6
+    ]
+  },
+  {
+    "question": "1 - 8 =",
+    "correct": -7,
+    "choices": [
+      3,
+      -7,
+      -9,
+      10
+    ]
+  },
+  {
+    "question": "1 - 9 =",
+    "correct": -8,
+    "choices": [
+      6,
+      -8,
+      -6,
+      -7
+    ]
+  },
+  {
+    "question": "2 - 1 =",
+    "correct": 1,
+    "choices": [
+      -3,
+      -10,
+      1,
+      6
+    ]
+  },
+  {
+    "question": "2 - 2 =",
+    "correct": 0,
+    "choices": [
+      4,
+      0,
+      10,
+      6
+    ]
+  },
+  {
+    "question": "2 - 3 =",
+    "correct": -1,
+    "choices": [
+      -1,
+      -4,
+      -5,
+      10
+    ]
+  },
+  {
+    "question": "2 - 4 =",
+    "correct": -2,
+    "choices": [
+      2,
+      -2,
+      6,
+      -4
+    ]
+  },
+  {
+    "question": "2 - 5 =",
+    "correct": -3,
+    "choices": [
+      0,
+      -1,
+      -3,
+      7
+    ]
+  },
+  {
+    "question": "2 - 6 =",
+    "correct": -4,
+    "choices": [
+      -4,
+      -6,
+      -10,
+      -8
+    ]
+  },
+  {
+    "question": "2 - 7 =",
+    "correct": -5,
+    "choices": [
+      -3,
+      -5,
+      5,
+      3
+    ]
+  },
+  {
+    "question": "2 - 8 =",
+    "correct": -6,
+    "choices": [
+      10,
+      -2,
+      0,
+      -6
+    ]
+  },
+  {
+    "question": "2 - 9 =",
+    "correct": -7,
+    "choices": [
+      1,
+      -3,
+      -7,
+      -8
+    ]
+  },
+  {
+    "question": "3 - 1 =",
+    "correct": 2,
+    "choices": [
+      -4,
+      2,
+      7,
+      8
+    ]
+  },
+  {
+    "question": "3 - 2 =",
+    "correct": 1,
+    "choices": [
+      1,
+      -2,
+      -5,
+      -4
+    ]
+  },
+  {
+    "question": "3 - 3 =",
+    "correct": 0,
+    "choices": [
+      -10,
+      1,
+      0,
+      7
+    ]
+  },
+  {
+    "question": "3 - 4 =",
+    "correct": -1,
+    "choices": [
+      0,
+      -3,
+      9,
+      -1
+    ]
+  },
+  {
+    "question": "3 - 5 =",
+    "correct": -2,
+    "choices": [
+      2,
+      -5,
+      -2,
+      8
+    ]
+  },
+  {
+    "question": "3 - 6 =",
+    "correct": -3,
+    "choices": [
+      -6,
+      -3,
+      8,
+      -4
+    ]
+  },
+  {
+    "question": "3 - 7 =",
+    "correct": -4,
+    "choices": [
+      10,
+      -5,
+      -4,
+      -9
+    ]
+  },
+  {
+    "question": "3 - 8 =",
+    "correct": -5,
+    "choices": [
+      -1,
+      8,
+      2,
+      -5
+    ]
+  },
+  {
+    "question": "3 - 9 =",
+    "correct": -6,
+    "choices": [
+      10,
+      8,
+      -6,
+      -9
+    ]
+  },
+  {
+    "question": "4 - 1 =",
+    "correct": 3,
+    "choices": [
+      10,
+      3,
+      8,
+      6
+    ]
+  },
+  {
+    "question": "4 - 2 =",
+    "correct": 2,
+    "choices": [
+      9,
+      -1,
+      5,
+      2
+    ]
+  },
+  {
+    "question": "4 - 3 =",
+    "correct": 1,
+    "choices": [
+      -9,
+      8,
+      -3,
+      1
+    ]
+  },
+  {
+    "question": "4 - 4 =",
+    "correct": 0,
+    "choices": [
+      0,
+      -7,
+      7,
+      6
+    ]
+  },
+  {
+    "question": "4 - 5 =",
+    "correct": -1,
+    "choices": [
+      3,
+      -8,
+      4,
+      -1
+    ]
+  },
+  {
+    "question": "4 - 6 =",
+    "correct": -2,
+    "choices": [
+      -8,
+      7,
+      -2,
+      8
+    ]
+  },
+  {
+    "question": "4 - 7 =",
+    "correct": -3,
+    "choices": [
+      1,
+      5,
+      -3,
+      6
+    ]
+  },
+  {
+    "question": "4 - 8 =",
+    "correct": -4,
+    "choices": [
+      -2,
+      7,
+      -8,
+      -4
+    ]
+  },
+  {
+    "question": "4 - 9 =",
+    "correct": -5,
+    "choices": [
+      0,
+      -10,
+      -5,
+      -2
+    ]
+  },
+  {
+    "question": "5 - 1 =",
+    "correct": 4,
+    "choices": [
+      4,
+      3,
+      -6,
+      9
+    ]
+  },
+  {
+    "question": "5 - 2 =",
+    "correct": 3,
+    "choices": [
+      7,
+      4,
+      -7,
+      3
+    ]
+  },
+  {
+    "question": "5 - 3 =",
+    "correct": 2,
+    "choices": [
+      6,
+      2,
+      8,
+      10
+    ]
+  },
+  {
+    "question": "5 - 4 =",
+    "correct": 1,
+    "choices": [
+      3,
+      1,
+      -10,
+      2
+    ]
+  },
+  {
+    "question": "5 - 5 =",
+    "correct": 0,
+    "choices": [
+      -3,
+      0,
+      6,
+      -4
+    ]
+  },
+  {
+    "question": "5 - 6 =",
+    "correct": -1,
+    "choices": [
+      6,
+      -3,
+      -1,
+      2
+    ]
+  },
+  {
+    "question": "5 - 7 =",
+    "correct": -2,
+    "choices": [
+      8,
+      4,
+      -2,
+      9
+    ]
+  },
+  {
+    "question": "5 - 8 =",
+    "correct": -3,
+    "choices": [
+      -2,
+      -3,
+      -6,
+      -9
+    ]
+  },
+  {
+    "question": "5 - 9 =",
+    "correct": -4,
+    "choices": [
+      -9,
+      3,
+      4,
+      -4
+    ]
+  },
+  {
+    "question": "6 - 1 =",
+    "correct": 5,
+    "choices": [
+      5,
+      2,
+      -2,
+      0
+    ]
+  },
+  {
+    "question": "6 - 2 =",
+    "correct": 4,
+    "choices": [
+      -8,
+      -3,
+      4,
+      9
+    ]
+  },
+  {
+    "question": "6 - 3 =",
+    "correct": 3,
+    "choices": [
+      3,
+      -2,
+      -3,
+      -7
+    ]
+  },
+  {
+    "question": "6 - 4 =",
+    "correct": 2,
+    "choices": [
+      2,
+      7,
+      6,
+      -3
+    ]
+  },
+  {
+    "question": "6 - 5 =",
+    "correct": 1,
+    "choices": [
+      -8,
+      6,
+      1,
+      -5
+    ]
+  },
+  {
+    "question": "6 - 6 =",
+    "correct": 0,
+    "choices": [
+      2,
+      10,
+      1,
+      0
+    ]
+  },
+  {
+    "question": "6 - 7 =",
+    "correct": -1,
+    "choices": [
+      -7,
+      4,
+      -5,
+      -1
+    ]
+  },
+  {
+    "question": "6 - 8 =",
+    "correct": -2,
+    "choices": [
+      2,
+      6,
+      3,
+      -2
+    ]
+  },
+  {
+    "question": "6 - 9 =",
+    "correct": -3,
+    "choices": [
+      -3,
+      -10,
+      7,
+      9
+    ]
+  },
+  {
+    "question": "7 - 1 =",
+    "correct": 6,
+    "choices": [
+      6,
+      -8,
+      -6,
+      7
+    ]
+  },
+  {
+    "question": "7 - 2 =",
+    "correct": 5,
+    "choices": [
+      -4,
+      5,
+      3,
+      -1
+    ]
+  },
+  {
+    "question": "7 - 3 =",
+    "correct": 4,
+    "choices": [
+      4,
+      -9,
+      -6,
+      1
+    ]
+  },
+  {
+    "question": "7 - 4 =",
+    "correct": 3,
+    "choices": [
+      10,
+      3,
+      1,
+      9
+    ]
+  },
+  {
+    "question": "7 - 5 =",
+    "correct": 2,
+    "choices": [
+      -2,
+      7,
+      2,
+      -7
+    ]
+  },
+  {
+    "question": "7 - 6 =",
+    "correct": 1,
+    "choices": [
+      6,
+      -2,
+      -8,
+      1
+    ]
+  },
+  {
+    "question": "7 - 7 =",
+    "correct": 0,
+    "choices": [
+      -5,
+      0,
+      8,
+      10
+    ]
+  },
+  {
+    "question": "7 - 8 =",
+    "correct": -1,
+    "choices": [
+      -4,
+      -2,
+      6,
+      -1
+    ]
+  },
+  {
+    "question": "7 - 9 =",
+    "correct": -2,
+    "choices": [
+      -8,
+      -2,
+      -9,
+      -1
+    ]
+  },
+  {
+    "question": "8 - 1 =",
+    "correct": 7,
+    "choices": [
+      9,
+      7,
+      8,
+      -1
+    ]
+  },
+  {
+    "question": "8 - 2 =",
+    "correct": 6,
+    "choices": [
+      -9,
+      6,
+      9,
+      -5
+    ]
+  },
+  {
+    "question": "8 - 3 =",
+    "correct": 5,
+    "choices": [
+      -2,
+      9,
+      5,
+      6
+    ]
+  },
+  {
+    "question": "8 - 4 =",
+    "correct": 4,
+    "choices": [
+      7,
+      10,
+      6,
+      4
+    ]
+  },
+  {
+    "question": "8 - 5 =",
+    "correct": 3,
+    "choices": [
+      4,
+      5,
+      3,
+      -5
+    ]
+  },
+  {
+    "question": "8 - 6 =",
+    "correct": 2,
+    "choices": [
+      2,
+      -1,
+      7,
+      -3
+    ]
+  },
+  {
+    "question": "8 - 7 =",
+    "correct": 1,
+    "choices": [
+      -10,
+      1,
+      -7,
+      7
+    ]
+  },
+  {
+    "question": "8 - 8 =",
+    "correct": 0,
+    "choices": [
+      3,
+      -5,
+      0,
+      1
+    ]
+  },
+  {
+    "question": "8 - 9 =",
+    "correct": -1,
+    "choices": [
+      1,
+      3,
+      -9,
+      -1
+    ]
+  },
+  {
+    "question": "9 - 1 =",
+    "correct": 8,
+    "choices": [
+      10,
+      -7,
+      8,
+      5
+    ]
+  },
+  {
+    "question": "9 - 2 =",
+    "correct": 7,
+    "choices": [
+      5,
+      7,
+      -10,
+      1
+    ]
+  },
+  {
+    "question": "9 - 3 =",
+    "correct": 6,
+    "choices": [
+      10,
+      -3,
+      -1,
+      6
+    ]
+  },
+  {
+    "question": "9 - 4 =",
+    "correct": 5,
+    "choices": [
+      -5,
+      5,
+      -6,
+      -7
+    ]
+  },
+  {
+    "question": "9 - 5 =",
+    "correct": 4,
+    "choices": [
+      1,
+      4,
+      2,
+      -10
+    ]
+  },
+  {
+    "question": "9 - 6 =",
+    "correct": 3,
+    "choices": [
+      -3,
+      -5,
+      3,
+      -1
+    ]
+  },
+  {
+    "question": "9 - 7 =",
+    "correct": 2,
+    "choices": [
+      -1,
+      7,
+      2,
+      1
+    ]
+  },
+  {
+    "question": "9 - 8 =",
+    "correct": 1,
+    "choices": [
+      1,
+      -5,
+      -4,
+      -10
+    ]
+  },
+  {
+    "question": "9 - 9 =",
+    "correct": 0,
+    "choices": [
+      -2,
+      1,
+      0,
+      7
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- generate new arithmetic quiz JSON files for subtraction, multiplication, division, and mixed problems
- support double-digit arithmetic for all four operations
- add all new quiz categories under the math guild
- load new quizzes through `quizData.ts`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685652caada88322bcfa113f3c8b22ae