### PR TITLE
Show start screen only once

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,10 @@ const App: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [attackEffect, setAttackEffect] = useState<'player-attack' | 'enemy-attack' | null>(null);
   const [showWarning, setShowWarning] = useState(false);
+  // Controls whether the CategorySelect component should display the start screen.
+  // Once the start screen is shown and the user taps START, this becomes false
+  // so that returning from the result screen skips the start screen.
+  const [showStartScreen, setShowStartScreen] = useState(true);
   const getEnemyHpForFloor = (floor: number) => (floor % 10 === 0 ? 20 : 5);
   const [shuffledQuizzes, setShuffledQuizzes] = useState<Quiz[]>([]);
   const [selectedEnemyImage, setSelectedEnemyImage] = useState<string>("");
@@ -243,7 +247,13 @@ const App: React.FC = () => {
 
   // 画面の表示制御
   if (currentScreen === 'category') {
-    return <CategorySelect onCategorySelect={handleCategorySelect} />;
+    return (
+      <CategorySelect
+        onCategorySelect={handleCategorySelect}
+        showStartScreen={showStartScreen}
+        onStart={() => setShowStartScreen(false)}
+      />
+    );
   }
 
   if (currentScreen === 'game' && selectedCategory) {

--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -4,6 +4,16 @@ import { BGM, SOUND_EFFECTS, BACKGROUND_IMAGES } from '../constants';
 
 interface CategorySelectProps {
   onCategorySelect: (categoryId: string) => void;
+  /**
+   * Whether the start screen should be displayed on mount.
+   */
+  showStartScreen: boolean;
+  /**
+   * Callback fired when the user taps the START button.
+   * Used by the parent component to mark the start screen as shown
+   * so it will not appear again during this session.
+   */
+  onStart: () => void;
 }
 
 type Screen = 'start' | 'map' | 'board';
@@ -62,8 +72,14 @@ const MUSIC = {
   map: BGM.category
 };
 
-const CategorySelect: React.FC<CategorySelectProps> = ({ onCategorySelect }) => {
-  const [screen, setScreen] = useState<Screen>('start');
+const CategorySelect: React.FC<CategorySelectProps> = ({
+  onCategorySelect,
+  showStartScreen,
+  onStart
+}) => {
+  const [screen, setScreen] = useState<Screen>(() =>
+    showStartScreen ? 'start' : 'map'
+  );
   const [activeGuild, setActiveGuild] = useState<typeof guilds[number] | null>(null);
   const [audioReady, setAudioReady] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -143,6 +159,7 @@ const CategorySelect: React.FC<CategorySelectProps> = ({ onCategorySelect }) => 
     playSE('uiStart');
     startBGM();
     setScreen('map');
+    onStart();
   };
 
   // ギルド選択


### PR DESCRIPTION
## Summary
- add `showStartScreen` state in `App` to track whether the start screen should display
- extend `CategorySelect` to receive props controlling start display and notify when the START button is pressed
- skip the start screen when returning from results

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6857a18d5bb0832280f1730384d5876c