### PR TITLE
Add English Guild Level 2 quizzes

### DIFF
--- a/src/data/categories.json
+++ b/src/data/categories.json
@@ -180,6 +180,96 @@
     "file": "quizzes/english/english_lv10.json"
   },
   {
+    "id": "english2_lv1",
+    "name": "同音異義語（レベル1）",
+    "description": "発音が同じで意味が異なる語を選ぶ問題です",
+    "icon": "🔊",
+    "difficulty": "★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv1_homophones.json"
+  },
+  {
+    "id": "english2_lv2",
+    "name": "反対語・類義語（レベル2）",
+    "description": "単語の反対語や類義語を選ぶ問題です",
+    "icon": "🔁",
+    "difficulty": "★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv2_antonyms_synonyms.json"
+  },
+  {
+    "id": "english2_lv3",
+    "name": "熟語・句動詞（レベル3）",
+    "description": "基本的な熟語や句動詞の意味を問う問題です",
+    "icon": "📘",
+    "difficulty": "★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv3_phrasal_verbs.json"
+  },
+  {
+    "id": "english2_lv4",
+    "name": "会話穴埋め（レベル4）",
+    "description": "会話文の空欄に入る語を選ぶ問題です",
+    "icon": "💭",
+    "difficulty": "★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv4_dialogue_fill.json"
+  },
+  {
+    "id": "english2_lv5",
+    "name": "品詞の見分け（レベル5）",
+    "description": "単語の品詞を判断する問題です",
+    "icon": "✏️",
+    "difficulty": "★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv5_parts_of_speech.json"
+  },
+  {
+    "id": "english2_lv6",
+    "name": "英語の説明（レベル6）",
+    "description": "簡単な英語の説明から語を選ぶ問題です",
+    "icon": "📚",
+    "difficulty": "★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv6_english_definitions.json"
+  },
+  {
+    "id": "english2_lv7",
+    "name": "語順並び替え（レベル7）",
+    "description": "語の正しい並び順を選ぶ問題です",
+    "icon": "📝",
+    "difficulty": "★★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv7_sentence_order.json"
+  },
+  {
+    "id": "english2_lv8",
+    "name": "短文整序（レベル8）",
+    "description": "短い文章の順序を選ぶ問題です",
+    "icon": "📑",
+    "difficulty": "★★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv8_short_paragraph_order.json"
+  },
+  {
+    "id": "english2_lv9",
+    "name": "文化と習慣（レベル9）",
+    "description": "英語圏の文化や習慣に関する問題です",
+    "icon": "🌍",
+    "difficulty": "★★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv9_culture_customs.json"
+  },
+  {
+    "id": "english2_lv10",
+    "name": "文法訂正（レベル10）",
+    "description": "誤った英文から正しい形を選ぶ問題です",
+    "icon": "✅",
+    "difficulty": "★★★★",
+    "clearFloor": 10,
+    "file": "quizzes/english2/lv10_sentence_correction.json"
+  },
+  {
     "id": "basic_math_lv1",
     "name": "足し算・引き算（レベル1）",
     "description": "一桁＋一桁の足し算問題です",

--- a/src/data/guilds.json
+++ b/src/data/guilds.json
@@ -18,6 +18,24 @@
     ]
   },
   {
+    "id": "english2",
+    "name": "英語ギルドレベル2（応用）",
+    "icon": "🗺️",
+    "position": { "top": "33%", "left": "75%" },
+    "categoryIds": [
+      "english2_lv1",
+      "english2_lv2",
+      "english2_lv3",
+      "english2_lv4",
+      "english2_lv5",
+      "english2_lv6",
+      "english2_lv7",
+      "english2_lv8",
+      "english2_lv9",
+      "english2_lv10"
+    ]
+  },
+  {
     "id": "arithmetic",
     "name": "算数ギルド★★",
     "icon": "🧠",

--- a/src/data/quizManager.ts
+++ b/src/data/quizManager.ts
@@ -24,6 +24,16 @@ import english_lv7 from './quizzes/english/english_lv7.json';
 import english_lv8 from './quizzes/english/english_lv8.json';
 import english_lv9 from './quizzes/english/english_lv9.json';
 import english_lv10 from './quizzes/english/english_lv10.json';
+import english2_lv1 from './quizzes/english2/lv1_homophones.json';
+import english2_lv2 from './quizzes/english2/lv2_antonyms_synonyms.json';
+import english2_lv3 from './quizzes/english2/lv3_phrasal_verbs.json';
+import english2_lv4 from './quizzes/english2/lv4_dialogue_fill.json';
+import english2_lv5 from './quizzes/english2/lv5_parts_of_speech.json';
+import english2_lv6 from './quizzes/english2/lv6_english_definitions.json';
+import english2_lv7 from './quizzes/english2/lv7_sentence_order.json';
+import english2_lv8 from './quizzes/english2/lv8_short_paragraph_order.json';
+import english2_lv9 from './quizzes/english2/lv9_culture_customs.json';
+import english2_lv10 from './quizzes/english2/lv10_sentence_correction.json';
 
 // 基本算数クイズ
 import basic_math_lv1 from './quizzes/basic_math/basic_math_lv1.json';
@@ -90,6 +100,16 @@ const quizImportMap: Record<string, any> = {
   'quizzes/english/english_lv8.json': english_lv8,
   'quizzes/english/english_lv9.json': english_lv9,
   'quizzes/english/english_lv10.json': english_lv10,
+  'quizzes/english2/lv1_homophones.json': english2_lv1,
+  'quizzes/english2/lv2_antonyms_synonyms.json': english2_lv2,
+  'quizzes/english2/lv3_phrasal_verbs.json': english2_lv3,
+  'quizzes/english2/lv4_dialogue_fill.json': english2_lv4,
+  'quizzes/english2/lv5_parts_of_speech.json': english2_lv5,
+  'quizzes/english2/lv6_english_definitions.json': english2_lv6,
+  'quizzes/english2/lv7_sentence_order.json': english2_lv7,
+  'quizzes/english2/lv8_short_paragraph_order.json': english2_lv8,
+  'quizzes/english2/lv9_culture_customs.json': english2_lv9,
+  'quizzes/english2/lv10_sentence_correction.json': english2_lv10,
   
   // 基本算数クイズ
   'quizzes/basic_math/basic_math_lv1.json': basic_math_lv1,

--- a/src/data/quizzes/english2/lv10_sentence_correction.json
+++ b/src/data/quizzes/english2/lv10_sentence_correction.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "He goes to school every day.",
+    "choices": ["He go to school every day.", "He goes to school every day.", "He going to school every day.", "He gone to school every day."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "She doesn't like carrots.",
+    "choices": ["She don't like carrots.", "She doesn't like carrots.", "She not like carrots.", "She isn't like carrots."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "We were watching a movie.",
+    "choices": ["We was watching a movie.", "We were watching a movie.", "We watching a movie.", "We were watch a movie."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "They have finished their work.",
+    "choices": ["They has finished their work.", "They have finish their work.", "They have finished their work.", "They had finish their work."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "I am going to study tonight.",
+    "choices": ["I going to study tonight.", "I am going to study tonight.", "I am go to study tonight.", "I am going study tonight."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "Does he play the guitar?",
+    "choices": ["Do he play the guitar?", "Does he play the guitar?", "Does he plays the guitar?", "He does play the guitar?"]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "There are many books on the shelf.",
+    "choices": ["There is many books on the shelf.", "There are many books on the shelf.", "There be many books on the shelf.", "There many books on the shelf."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "My brother and I were happy.",
+    "choices": ["My brother and I was happy.", "My brother and I were happy.", "Me and my brother was happy.", "Me and my brother were happy."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "She has lived here for five years.",
+    "choices": ["She have lived here for five years.", "She has lived here for five years.", "She has live here for five years.", "She had lived here for five years."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "We will meet at three o'clock.",
+    "choices": ["We will meets at three o'clock.", "We will meet at three o'clock.", "We will met at three o'clock.", "We meet will at three o'clock."]
+  }
+]

--- a/src/data/quizzes/english2/lv1_homophones.json
+++ b/src/data/quizzes/english2/lv1_homophones.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Which word sounds like 'see' but means a large body of water?",
+    "correct": "sea",
+    "choices": ["sea", "see", "sew", "say"]
+  },
+  {
+    "question": "Which word sounds like 'flower' but is used in baking?",
+    "correct": "flour",
+    "choices": ["flour", "flower", "floor", "flow"]
+  },
+  {
+    "question": "Which word sounds like 'two' and means the number 2?",
+    "correct": "two",
+    "choices": ["to", "too", "two", "tow"]
+  },
+  {
+    "question": "Which word sounds like 'night' but means a brave fighter?",
+    "correct": "knight",
+    "choices": ["night", "knight", "kite", "right"]
+  },
+  {
+    "question": "Which word sounds like 'sun' but means a male child?",
+    "correct": "son",
+    "choices": ["son", "sun", "soon", "swan"]
+  },
+  {
+    "question": "Which word sounds like 'plane' and means ordinary?",
+    "correct": "plain",
+    "choices": ["plane", "plain", "plan", "play"]
+  },
+  {
+    "question": "Which word sounds like 'write' but means correct?",
+    "correct": "right",
+    "choices": ["rite", "right", "write", "riot"]
+  },
+  {
+    "question": "Which word sounds like 'won' and is the number one?",
+    "correct": "one",
+    "choices": ["won", "one", "on", "wan"]
+  },
+  {
+    "question": "Which word sounds like 'sail' and means to sell something?",
+    "correct": "sale",
+    "choices": ["sail", "sale", "seal", "same"]
+  },
+  {
+    "question": "Which word sounds like 'meet' but is food from animals?",
+    "correct": "meat",
+    "choices": ["meat", "meet", "met", "mate"]
+  }
+]

--- a/src/data/quizzes/english2/lv2_antonyms_synonyms.json
+++ b/src/data/quizzes/english2/lv2_antonyms_synonyms.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Which word is the opposite of 'cold'?",
+    "correct": "hot",
+    "choices": ["warm", "hot", "cool", "ice"]
+  },
+  {
+    "question": "Which word means the same as 'big'?",
+    "correct": "large",
+    "choices": ["small", "tiny", "large", "narrow"]
+  },
+  {
+    "question": "Which word is the opposite of 'early'?",
+    "correct": "late",
+    "choices": ["late", "soon", "fast", "quick"]
+  },
+  {
+    "question": "Which word means the same as 'happy'?",
+    "correct": "glad",
+    "choices": ["sad", "glad", "angry", "mad"]
+  },
+  {
+    "question": "Which word is the opposite of 'up'?",
+    "correct": "down",
+    "choices": ["down", "over", "near", "above"]
+  },
+  {
+    "question": "Which word means the same as 'begin'?",
+    "correct": "start",
+    "choices": ["finish", "start", "stop", "end"]
+  },
+  {
+    "question": "Which word is the opposite of 'heavy'?",
+    "correct": "light",
+    "choices": ["light", "big", "large", "hard"]
+  },
+  {
+    "question": "Which word means the same as 'fast'?",
+    "correct": "quick",
+    "choices": ["slow", "quick", "late", "lazy"]
+  },
+  {
+    "question": "Which word is the opposite of 'old'?",
+    "correct": "young",
+    "choices": ["new", "young", "ancient", "used"]
+  },
+  {
+    "question": "Which word means the same as 'smart'?",
+    "correct": "clever",
+    "choices": ["clever", "dull", "slow", "tired"]
+  }
+]

--- a/src/data/quizzes/english2/lv3_phrasal_verbs.json
+++ b/src/data/quizzes/english2/lv3_phrasal_verbs.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "What does 'look after' mean?",
+    "correct": "take care of",
+    "choices": ["ignore", "take care of", "leave", "forget"]
+  },
+  {
+    "question": "What does 'give up' mean?",
+    "correct": "stop trying",
+    "choices": ["start", "keep", "stop trying", "finish"]
+  },
+  {
+    "question": "What does 'turn on' mean?",
+    "correct": "start",
+    "choices": ["start", "stop", "move", "break"]
+  },
+  {
+    "question": "What does 'pick up' mean?",
+    "correct": "collect",
+    "choices": ["drop", "collect", "push", "hide"]
+  },
+  {
+    "question": "What does 'find out' mean?",
+    "correct": "discover",
+    "choices": ["discover", "lose", "cover", "close"]
+  },
+  {
+    "question": "What does 'put off' mean?",
+    "correct": "delay",
+    "choices": ["delay", "hurry", "start", "finish"]
+  },
+  {
+    "question": "What does 'run out of' mean?",
+    "correct": "have no more",
+    "choices": ["have no more", "add more", "give away", "find more"]
+  },
+  {
+    "question": "What does 'take off' mean?",
+    "correct": "remove",
+    "choices": ["remove", "put on", "repair", "carry"]
+  },
+  {
+    "question": "What does 'call back' mean?",
+    "correct": "return a call",
+    "choices": ["forget", "answer", "return a call", "hang up"]
+  },
+  {
+    "question": "What does 'set up' mean?",
+    "correct": "arrange",
+    "choices": ["arrange", "destroy", "delay", "cancel"]
+  }
+]

--- a/src/data/quizzes/english2/lv4_dialogue_fill.json
+++ b/src/data/quizzes/english2/lv4_dialogue_fill.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "A: Hi, how are you? B: I'm ___, thanks.",
+    "correct": "fine",
+    "choices": ["fine", "open", "late", "past"]
+  },
+  {
+    "question": "A: Do you like cake? B: Yes, I ___.",
+    "correct": "do",
+    "choices": ["am", "do", "did", "does"]
+  },
+  {
+    "question": "A: What time is it? B: It's ___ o'clock.",
+    "correct": "five",
+    "choices": ["five", "day", "eat", "run"]
+  },
+  {
+    "question": "A: Let's play soccer. B: ___, let's go!",
+    "correct": "Sure",
+    "choices": ["No", "Sure", "Later", "Never"]
+  },
+  {
+    "question": "A: I'm hungry. B: Have some ___.",
+    "correct": "bread",
+    "choices": ["bread", "read", "broad", "break"]
+  },
+  {
+    "question": "A: Where is my phone? B: It's over ___.",
+    "correct": "there",
+    "choices": ["their", "they're", "there", "them"]
+  },
+  {
+    "question": "A: I can't do this homework. B: Let me ___ you.",
+    "correct": "help",
+    "choices": ["help", "hop", "hope", "heap"]
+  },
+  {
+    "question": "A: See you tomorrow. B: ___!",
+    "correct": "Bye",
+    "choices": ["Bye", "Why", "Buy", "Shy"]
+  },
+  {
+    "question": "A: What's your name? B: My name ___ Ken.",
+    "correct": "is",
+    "choices": ["are", "is", "am", "be"]
+  },
+  {
+    "question": "A: Is this your book? B: Yes, it's ___.",
+    "correct": "mine",
+    "choices": ["mine", "mind", "mime", "mean"]
+  }
+]

--- a/src/data/quizzes/english2/lv5_parts_of_speech.json
+++ b/src/data/quizzes/english2/lv5_parts_of_speech.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "What part of speech is 'happy'?",
+    "correct": "adjective",
+    "choices": ["noun", "adjective", "verb", "adverb"]
+  },
+  {
+    "question": "What part of speech is 'run' in 'I run fast'?",
+    "correct": "verb",
+    "choices": ["noun", "adjective", "verb", "adverb"]
+  },
+  {
+    "question": "What part of speech is 'slowly'?",
+    "correct": "adverb",
+    "choices": ["noun", "verb", "adverb", "adjective"]
+  },
+  {
+    "question": "What part of speech is 'teacher'?",
+    "correct": "noun",
+    "choices": ["verb", "adjective", "adverb", "noun"]
+  },
+  {
+    "question": "What part of speech is 'beautiful'?",
+    "correct": "adjective",
+    "choices": ["adjective", "verb", "noun", "adverb"]
+  },
+  {
+    "question": "What part of speech is 'quickly'?",
+    "correct": "adverb",
+    "choices": ["adverb", "verb", "adjective", "noun"]
+  },
+  {
+    "question": "What part of speech is 'eat'?",
+    "correct": "verb",
+    "choices": ["noun", "verb", "adjective", "adverb"]
+  },
+  {
+    "question": "What part of speech is 'desk'?",
+    "correct": "noun",
+    "choices": ["noun", "verb", "adjective", "adverb"]
+  },
+  {
+    "question": "What part of speech is 'interesting'?",
+    "correct": "adjective",
+    "choices": ["verb", "adverb", "adjective", "noun"]
+  },
+  {
+    "question": "What part of speech is 'sing'?",
+    "correct": "verb",
+    "choices": ["adjective", "verb", "noun", "adverb"]
+  }
+]

--- a/src/data/quizzes/english2/lv6_english_definitions.json
+++ b/src/data/quizzes/english2/lv6_english_definitions.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "A fruit that is red and round",
+    "correct": "apple",
+    "choices": ["banana", "apple", "grape", "pear"]
+  },
+  {
+    "question": "An animal that barks",
+    "correct": "dog",
+    "choices": ["cat", "bird", "dog", "cow"]
+  },
+  {
+    "question": "A place where you sleep at night",
+    "correct": "bed",
+    "choices": ["desk", "bed", "car", "chair"]
+  },
+  {
+    "question": "A thing you use to write",
+    "correct": "pen",
+    "choices": ["cup", "pen", "spoon", "plate"]
+  },
+  {
+    "question": "A large vehicle that flies",
+    "correct": "airplane",
+    "choices": ["bicycle", "airplane", "car", "ship"]
+  },
+  {
+    "question": "Something you drink in the morning, made from beans",
+    "correct": "coffee",
+    "choices": ["water", "coffee", "juice", "milk"]
+  },
+  {
+    "question": "A person who teaches students",
+    "correct": "teacher",
+    "choices": ["doctor", "teacher", "driver", "singer"]
+  },
+  {
+    "question": "A device to call people",
+    "correct": "phone",
+    "choices": ["book", "phone", "table", "paper"]
+  },
+  {
+    "question": "A building where you can read many books",
+    "correct": "library",
+    "choices": ["hospital", "library", "school", "station"]
+  },
+  {
+    "question": "A season when leaves fall",
+    "correct": "autumn",
+    "choices": ["spring", "summer", "autumn", "winter"]
+  }
+]

--- a/src/data/quizzes/english2/lv7_sentence_order.json
+++ b/src/data/quizzes/english2/lv7_sentence_order.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Choose the correct order: like / I / pizza",
+    "correct": "I like pizza",
+    "choices": ["like I pizza", "I pizza like", "I like pizza", "pizza I like"]
+  },
+  {
+    "question": "Choose the correct order: is / my / this / pen",
+    "correct": "this is my pen",
+    "choices": ["is pen my this", "this is my pen", "pen my this is", "my pen is this"]
+  },
+  {
+    "question": "Choose the correct order: you / do / homework",
+    "correct": "you do homework",
+    "choices": ["do homework you", "homework you do", "you do homework", "you homework do"]
+  },
+  {
+    "question": "Choose the correct order: play / we / soccer / today",
+    "correct": "we play soccer today",
+    "choices": ["play we soccer today", "we play soccer today", "soccer today we play", "today play we soccer"]
+  },
+  {
+    "question": "Choose the correct order: has / she / a / bike",
+    "correct": "she has a bike",
+    "choices": ["she has a bike", "has she a bike", "a bike she has", "bike a she has"]
+  },
+  {
+    "question": "Choose the correct order: is / where / the / station",
+    "correct": "where is the station",
+    "choices": ["station where is the", "where is the station", "is where the station", "the station where is"]
+  },
+  {
+    "question": "Choose the correct order: read / I / books",
+    "correct": "I read books",
+    "choices": ["read books I", "books I read", "I read books", "books read I"]
+  },
+  {
+    "question": "Choose the correct order: wants / he / to / study",
+    "correct": "he wants to study",
+    "choices": ["he wants to study", "wants he to study", "to study he wants", "study he wants to"]
+  },
+  {
+    "question": "Choose the correct order: dinner / make / let's",
+    "correct": "let's make dinner",
+    "choices": ["make dinner let's", "dinner make let's", "let's make dinner", "dinner let's make"]
+  },
+  {
+    "question": "Choose the correct order: was / rainy / it / yesterday",
+    "correct": "it was rainy yesterday",
+    "choices": ["rainy it was yesterday", "it rainy was yesterday", "it was rainy yesterday", "yesterday rainy it was"]
+  }
+]

--- a/src/data/quizzes/english2/lv8_short_paragraph_order.json
+++ b/src/data/quizzes/english2/lv8_short_paragraph_order.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Choose the correct order: (A) I wake up. (B) I eat breakfast. (C) I go to school.",
+    "correct": "A B C",
+    "choices": ["A C B", "A B C", "B A C", "C A B"]
+  },
+  {
+    "question": "Choose the correct order: (A) She opened the book. (B) She read it. (C) She closed it.",
+    "correct": "A B C",
+    "choices": ["B A C", "A B C", "A C B", "C B A"]
+  },
+  {
+    "question": "Choose the correct order: (A) It started to rain. (B) We took out umbrellas. (C) We went home.",
+    "correct": "A B C",
+    "choices": ["C B A", "A C B", "A B C", "B A C"]
+  },
+  {
+    "question": "Choose the correct order: (A) Tom cooked dinner. (B) We ate together. (C) We washed dishes.",
+    "correct": "A B C",
+    "choices": ["B A C", "A B C", "C B A", "A C B"]
+  },
+  {
+    "question": "Choose the correct order: (A) She bought a ticket. (B) She got on the bus. (C) She arrived at work.",
+    "correct": "A B C",
+    "choices": ["A B C", "B A C", "C A B", "B C A"]
+  },
+  {
+    "question": "Choose the correct order: (A) I turned on the TV. (B) I watched the news. (C) I turned it off.",
+    "correct": "A B C",
+    "choices": ["A C B", "B A C", "A B C", "C A B"]
+  },
+  {
+    "question": "Choose the correct order: (A) They met at the cafe. (B) They talked for an hour. (C) They said goodbye.",
+    "correct": "A B C",
+    "choices": ["B C A", "A B C", "A C B", "C A B"]
+  },
+  {
+    "question": "Choose the correct order: (A) I did my homework. (B) I played video games. (C) I went to bed.",
+    "correct": "A B C",
+    "choices": ["A C B", "B A C", "A B C", "C B A"]
+  },
+  {
+    "question": "Choose the correct order: (A) She put on her coat. (B) She opened the door. (C) She went outside.",
+    "correct": "A B C",
+    "choices": ["C B A", "A B C", "B C A", "A C B"]
+  },
+  {
+    "question": "Choose the correct order: (A) He studied hard. (B) He took the test. (C) He passed.",
+    "correct": "A B C",
+    "choices": ["A C B", "B A C", "A B C", "C B A"]
+  }
+]

--- a/src/data/quizzes/english2/lv9_culture_customs.json
+++ b/src/data/quizzes/english2/lv9_culture_customs.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Which holiday is in December?",
+    "correct": "Christmas",
+    "choices": ["Easter", "Halloween", "Christmas", "Thanksgiving"]
+  },
+  {
+    "question": "What drink is popular at British tea time?",
+    "correct": "tea",
+    "choices": ["coffee", "milk", "tea", "juice"]
+  },
+  {
+    "question": "Which sport is famous in the U.S. in fall?",
+    "correct": "American football",
+    "choices": ["American football", "cricket", "rugby", "tennis"]
+  },
+  {
+    "question": "Which country celebrates Thanksgiving?",
+    "correct": "United States",
+    "choices": ["France", "United States", "Japan", "Spain"]
+  },
+  {
+    "question": "What food is common at an English breakfast?",
+    "correct": "eggs",
+    "choices": ["eggs", "sushi", "tacos", "dumplings"]
+  },
+  {
+    "question": "Which city has the Statue of Liberty?",
+    "correct": "New York",
+    "choices": ["London", "New York", "Sydney", "Toronto"]
+  },
+  {
+    "question": "Which holiday uses pumpkins?",
+    "correct": "Halloween",
+    "choices": ["Christmas", "Halloween", "Easter", "New Year"]
+  },
+  {
+    "question": "In which month is Valentine's Day?",
+    "correct": "February",
+    "choices": ["February", "June", "October", "December"]
+  },
+  {
+    "question": "Which country is famous for the maple leaf?",
+    "correct": "Canada",
+    "choices": ["Canada", "Australia", "Mexico", "India"]
+  },
+  {
+    "question": "What is the traditional color for St. Patrick's Day?",
+    "correct": "green",
+    "choices": ["blue", "red", "green", "yellow"]
+  }
+]


### PR DESCRIPTION
## Summary
- add Level2 English quiz set with 100 new questions
- register new categories and guild
- import quizzes in quiz manager

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685954b43eec8322b8f46f3a1d012298