### PR TITLE
Add English Guild Level 3 advanced quizzes

### DIFF
--- a/src/data/quizzes/english3/lv10_error_correction.json
+++ b/src/data/quizzes/english3/lv10_error_correction.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "She doesn't like milk.",
+    "choices": ["She don't like milk.", "She doesn't like milk.", "She isn't like milk.", "She not like milk."]
+  },
+  {
+    "question": "Select the correct form.",
+    "correct": "They were happy yesterday.",
+    "choices": ["They was happy yesterday.", "They were happy yesterday.", "They are happy yesterday.", "They be happy yesterday."]
+  },
+  {
+    "question": "Which is right?",
+    "correct": "I have seen that movie.",
+    "choices": ["I saw that movie yet.", "I have saw that movie.", "I have seen that movie.", "I seen that movie."]
+  },
+  {
+    "question": "Find the correct sentence.",
+    "correct": "There are many books.",
+    "choices": ["There is many books.", "There are many books.", "There many books.", "There be many books."]
+  },
+  {
+    "question": "Choose the right sentence.",
+    "correct": "He speaks English well.",
+    "choices": ["He speak English well.", "He speaks English well.", "He speaking English well.", "He spoke English well."]
+  },
+  {
+    "question": "Select the correct wording.",
+    "correct": "My sister and I were late.",
+    "choices": ["My sister and me were late.", "My sister and I were late.", "Me and my sister was late.", "I and my sister were late."]
+  },
+  {
+    "question": "Which sentence is correct?",
+    "correct": "Does she play tennis?",
+    "choices": ["Do she play tennis?", "Does she play tennis?", "Is she play tennis?", "She does play tennis?"]
+  },
+  {
+    "question": "Find the correct form.",
+    "correct": "We enjoyed ourselves at the party.",
+    "choices": ["We enjoyed us at the party.", "We enjoyed ourselves at the party.", "We enjoy ourselves at the party.", "We enjoyed ourself at the party."]
+  },
+  {
+    "question": "Choose the correct sentence.",
+    "correct": "There were two dogs outside.",
+    "choices": ["There was two dogs outside.", "There were two dogs outside.", "There were two dog outside.", "There was two dog outside."]
+  },
+  {
+    "question": "Select the right sentence.",
+    "correct": "I'm interested in music.",
+    "choices": ["I'm interest in music.", "I'm interesting in music.", "I'm interested in music.", "I interested in music."]
+  }
+]

--- a/src/data/quizzes/english3/lv1_passive_voice.json
+++ b/src/data/quizzes/english3/lv1_passive_voice.json
@@ -1,0 +1,102 @@
+[
+  {
+    "question": "Which is a passive voice sentence?",
+    "correct": "The cake was eaten.",
+    "choices": [
+      "The cake was eaten.",
+      "He eats cake.",
+      "She is eating cake.",
+      "Eat the cake!"
+    ]
+  },
+  {
+    "question": "Which sentence uses passive voice correctly?",
+    "correct": "The window was broken.",
+    "choices": [
+      "The window was broken.",
+      "She broke the window.",
+      "He is breaking the window.",
+      "Break the window."
+    ]
+  },
+  {
+    "question": "Identify the passive form.",
+    "correct": "The car is washed.",
+    "choices": [
+      "The car is washed.",
+      "Wash the car.",
+      "He washes the car.",
+      "She is washing."
+    ]
+  },
+  {
+    "question": "Choose the passive sentence.",
+    "correct": "The song was sung.",
+    "choices": [
+      "The song was sung.",
+      "She sings the song.",
+      "They are singing.",
+      "Sing the song!"
+    ]
+  },
+  {
+    "question": "Which one is passive?",
+    "correct": "The homework was done.",
+    "choices": [
+      "The homework was done.",
+      "He did the homework.",
+      "She is doing homework.",
+      "Do the homework."
+    ]
+  },
+  {
+    "question": "Find the passive voice.",
+    "correct": "The letter was written.",
+    "choices": [
+      "The letter was written.",
+      "Write the letter.",
+      "He writes letters.",
+      "She is writing."
+    ]
+  },
+  {
+    "question": "Which is passive?",
+    "correct": "The house was built.",
+    "choices": [
+      "The house was built.",
+      "They build the house.",
+      "They are building.",
+      "Build the house."
+    ]
+  },
+  {
+    "question": "Select the passive form.",
+    "correct": "The door was opened.",
+    "choices": [
+      "The door was opened.",
+      "He opens the door.",
+      "Open the door!",
+      "She is opening it."
+    ]
+  },
+  {
+    "question": "Choose the correct passive voice.",
+    "correct": "The movie was watched.",
+    "choices": [
+      "The movie was watched.",
+      "We watch movies.",
+      "Watch the movie.",
+      "He is watching."
+    ]
+  },
+  {
+    "question": "Which sentence shows passive voice?",
+    "correct": "The game is played.",
+    "choices": [
+      "The game is played.",
+      "They play the game.",
+      "Play the game.",
+      "She is playing it."
+    ]
+  }
+]

--- a/src/data/quizzes/english3/lv2_relative_pronouns.json
+++ b/src/data/quizzes/english3/lv2_relative_pronouns.json
@@ -1,0 +1,62 @@
+[
+  {
+    "question": "Choose the correct pronoun: The boy ___ won is my friend.",
+    "correct": "who",
+    "choices": ["who", "which", "that", "where"]
+  },
+  {
+    "question": "This is the book ___ I like.",
+    "correct": "that",
+    "choices": ["who", "when", "that", "whose"]
+  },
+  {
+    "question": "Select the pronoun: She saw a dog ___ was hurt.",
+    "correct": "that",
+    "choices": ["who", "which", "that", "where"]
+  },
+  {
+    "question": "Which sentence uses 'who' correctly?",
+    "correct": "I met a girl who sings.",
+    "choices": [
+      "I met a girl who sings.",
+      "I met a girl which sings.",
+      "I met a girl where sings.",
+      "I met a girl when sings."
+    ]
+  },
+  {
+    "question": "Fill in the blank: The car ___ he bought is blue.",
+    "correct": "that",
+    "choices": ["who", "where", "that", "when"]
+  },
+  {
+    "question": "Choose the correct word: I like songs ___ are happy.",
+    "correct": "that",
+    "choices": ["who", "that", "where", "when"]
+  },
+  {
+    "question": "Select the sentence using 'which'.",
+    "correct": "This is the pen which writes well.",
+    "choices": [
+      "This is the pen which writes well.",
+      "This is the pen who writes well.",
+      "This is the pen where writes well.",
+      "This is the pen when writes well."
+    ]
+  },
+  {
+    "question": "Complete: The girl ___ father is a doctor is smart.",
+    "correct": "whose",
+    "choices": ["whose", "who", "where", "which"]
+  },
+  {
+    "question": "Choose the right pronoun: I know the man ___ you called.",
+    "correct": "whom",
+    "choices": ["whom", "who", "where", "which"]
+  },
+  {
+    "question": "Fill in: The house ___ Jack built is old.",
+    "correct": "that",
+    "choices": ["who", "that", "where", "whose"]
+  }
+]

--- a/src/data/quizzes/english3/lv3_verb_tenses.json
+++ b/src/data/quizzes/english3/lv3_verb_tenses.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Yesterday she ___ to the store.",
+    "correct": "went",
+    "choices": ["goes", "went", "will go", "going"]
+  },
+  {
+    "question": "I ___ dinner now.",
+    "correct": "am cooking",
+    "choices": ["cook", "am cooking", "cooked", "will cook"]
+  },
+  {
+    "question": "Tomorrow they ___ a movie.",
+    "correct": "will watch",
+    "choices": ["watch", "watched", "will watch", "watching"]
+  },
+  {
+    "question": "He usually ___ to school by bike.",
+    "correct": "goes",
+    "choices": ["go", "goes", "went", "going"]
+  },
+  {
+    "question": "She ___ her homework every day.",
+    "correct": "does",
+    "choices": ["did", "does", "doing", "will do"]
+  },
+  {
+    "question": "We ___ in this town since 2010.",
+    "correct": "have lived",
+    "choices": ["live", "lived", "have lived", "will live"]
+  },
+  {
+    "question": "They ___ lunch when I called.",
+    "correct": "were eating",
+    "choices": ["eat", "ate", "were eating", "will eat"]
+  },
+  {
+    "question": "By next year, I ___ here for five years.",
+    "correct": "will have worked",
+    "choices": ["work", "worked", "will work", "will have worked"]
+  },
+  {
+    "question": "If it rains, we ___ inside.",
+    "correct": "will stay",
+    "choices": ["stay", "stayed", "will stay", "staying"]
+  },
+  {
+    "question": "He ___ already finished his project.",
+    "correct": "has",
+    "choices": ["has", "have", "had", "will have"]
+  }
+]

--- a/src/data/quizzes/english3/lv4_comparison.json
+++ b/src/data/quizzes/english3/lv4_comparison.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Tom is ___ than Ken.",
+    "correct": "taller",
+    "choices": ["taller", "tall", "tallest", "more tall"]
+  },
+  {
+    "question": "This book is the ___ of the three.",
+    "correct": "longest",
+    "choices": ["long", "longer", "longest", "more long"]
+  },
+  {
+    "question": "My bag is ___ than yours.",
+    "correct": "heavier",
+    "choices": ["heavy", "heavier", "heaviest", "more heavy"]
+  },
+  {
+    "question": "She is the ___ student in class.",
+    "correct": "smartest",
+    "choices": ["smart", "smarter", "smartest", "more smart"]
+  },
+  {
+    "question": "This puzzle is ___ than that one.",
+    "correct": "easier",
+    "choices": ["easy", "easier", "easiest", "more easy"]
+  },
+  {
+    "question": "Mount Everest is the ___ mountain.",
+    "correct": "highest",
+    "choices": ["high", "higher", "highest", "most high"]
+  },
+  {
+    "question": "My car is ___ than his car.",
+    "correct": "faster",
+    "choices": ["fast", "faster", "fastest", "more fast"]
+  },
+  {
+    "question": "This is the ___ movie I have seen.",
+    "correct": "best",
+    "choices": ["good", "better", "best", "most good"]
+  },
+  {
+    "question": "Winter is ___ than autumn here.",
+    "correct": "colder",
+    "choices": ["cold", "colder", "coldest", "more cold"]
+  },
+  {
+    "question": "She sings ___ than anyone else.",
+    "correct": "better",
+    "choices": ["good", "better", "best", "well"]
+  }
+]

--- a/src/data/quizzes/english3/lv5_if_clauses.json
+++ b/src/data/quizzes/english3/lv5_if_clauses.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "If it rains, I ___ at home.",
+    "correct": "will stay",
+    "choices": ["stay", "stayed", "will stay", "staying"]
+  },
+  {
+    "question": "If I were you, I ___ the job.",
+    "correct": "would take",
+    "choices": ["take", "took", "would take", "taking"]
+  },
+  {
+    "question": "I get sleepy if I ___ too much.",
+    "correct": "study",
+    "choices": ["study", "studied", "studies", "studying"]
+  },
+  {
+    "question": "If she calls, ___ her I am busy.",
+    "correct": "tell",
+    "choices": ["told", "tell", "telling", "tells"]
+  },
+  {
+    "question": "We would go out if it ___ sunny.",
+    "correct": "were",
+    "choices": ["are", "was", "were", "be"]
+  },
+  {
+    "question": "If he had money, he ___ a car.",
+    "correct": "would buy",
+    "choices": ["buys", "bought", "would buy", "buying"]
+  },
+  {
+    "question": "If you mix red and blue, you ___ purple.",
+    "correct": "get",
+    "choices": ["got", "get", "will get", "getting"]
+  },
+  {
+    "question": "I will help you if I ___ time.",
+    "correct": "have",
+    "choices": ["had", "have", "has", "having"]
+  },
+  {
+    "question": "If they had left earlier, they ___ the bus.",
+    "correct": "would have caught",
+    "choices": ["catch", "caught", "would have caught", "will catch"]
+  },
+  {
+    "question": "If it ___ tomorrow, the event will stop.",
+    "correct": "rains",
+    "choices": ["rain", "rained", "rains", "raining"]
+  }
+]

--- a/src/data/quizzes/english3/lv6_reading_comprehension.json
+++ b/src/data/quizzes/english3/lv6_reading_comprehension.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "Tom went to the zoo yesterday. What did he visit?",
+    "correct": "the zoo",
+    "choices": ["the zoo", "the park", "the museum", "the store"]
+  },
+  {
+    "question": "Mary bought apples and bananas. What did she buy besides apples?",
+    "correct": "bananas",
+    "choices": ["oranges", "grapes", "bananas", "pears"]
+  },
+  {
+    "question": "Ken read a book before bed. When did he read?",
+    "correct": "before bed",
+    "choices": ["before bed", "at lunch", "in class", "after school"]
+  },
+  {
+    "question": "Sara likes dogs, but she has a cat. What pet does she have?",
+    "correct": "a cat",
+    "choices": ["a dog", "a bird", "a cat", "a fish"]
+  },
+  {
+    "question": "The movie starts at seven. When does it start?",
+    "correct": "at seven",
+    "choices": ["at six", "at seven", "at eight", "at nine"]
+  },
+  {
+    "question": "John plays soccer every weekend. What sport does he play?",
+    "correct": "soccer",
+    "choices": ["baseball", "tennis", "soccer", "basketball"]
+  },
+  {
+    "question": "They went hiking on Sunday. What did they do?",
+    "correct": "went hiking",
+    "choices": ["went swimming", "went hiking", "played games", "watched TV"]
+  },
+  {
+    "question": "Alice studied math for two hours. What subject did she study?",
+    "correct": "math",
+    "choices": ["science", "math", "history", "English"]
+  },
+  {
+    "question": "My father cooked dinner last night. Who cooked dinner?",
+    "correct": "my father",
+    "choices": ["my mother", "my father", "my sister", "my friend"]
+  },
+  {
+    "question": "The train arrived late. How did it arrive?",
+    "correct": "late",
+    "choices": ["early", "on time", "late", "quickly"]
+  }
+]

--- a/src/data/quizzes/english3/lv7_word_usage.json
+++ b/src/data/quizzes/english3/lv7_word_usage.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "He will ___ you a story tonight.",
+    "correct": "tell",
+    "choices": ["say", "tell", "speak", "talk"]
+  },
+  {
+    "question": "Please ___ clearly during the meeting.",
+    "correct": "speak",
+    "choices": ["say", "tell", "speak", "talk"]
+  },
+  {
+    "question": "She ___ she was tired.",
+    "correct": "said",
+    "choices": ["told", "said", "spoke", "talked"]
+  },
+  {
+    "question": "Can I ___ with you for a moment?",
+    "correct": "talk",
+    "choices": ["say", "tell", "speak", "talk"]
+  },
+  {
+    "question": "He ___ to the class yesterday.",
+    "correct": "spoke",
+    "choices": ["spoke", "told", "talked", "said"]
+  },
+  {
+    "question": "She ___ me to be careful.",
+    "correct": "told",
+    "choices": ["said", "told", "spoke", "talked"]
+  },
+  {
+    "question": "I want to ___ thanks to everyone.",
+    "correct": "say",
+    "choices": ["tell", "speak", "say", "talk"]
+  },
+  {
+    "question": "Let's ___ about your plan tomorrow.",
+    "correct": "talk",
+    "choices": ["speak", "tell", "talk", "say"]
+  },
+  {
+    "question": "She often ___ French at home.",
+    "correct": "speaks",
+    "choices": ["says", "tells", "speaks", "talks"]
+  },
+  {
+    "question": "He ___ he would come soon.",
+    "correct": "said",
+    "choices": ["spoke", "said", "told", "talked"]
+  }
+]

--- a/src/data/quizzes/english3/lv8_prepositions_advanced.json
+++ b/src/data/quizzes/english3/lv8_prepositions_advanced.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "He waited ___ the bus stop for an hour.",
+    "correct": "at",
+    "choices": ["in", "on", "by", "at"]
+  },
+  {
+    "question": "The cat jumped ___ the table.",
+    "correct": "onto",
+    "choices": ["into", "onto", "in", "on"]
+  },
+  {
+    "question": "She arrived ___ the airport at noon.",
+    "correct": "at",
+    "choices": ["in", "on", "at", "by"]
+  },
+  {
+    "question": "We walked ___ the river for miles.",
+    "correct": "along",
+    "choices": ["across", "along", "through", "over"]
+  },
+  {
+    "question": "He sat ___ the shade of the tree.",
+    "correct": "in",
+    "choices": ["on", "at", "by", "in"]
+  },
+  {
+    "question": "The book fell ___ the shelf.",
+    "correct": "off",
+    "choices": ["off", "of", "from", "out"]
+  },
+  {
+    "question": "She divided the cake ___ four pieces.",
+    "correct": "into",
+    "choices": ["into", "onto", "in", "to"]
+  },
+  {
+    "question": "I will arrive ___ Tokyo on Monday.",
+    "correct": "in",
+    "choices": ["on", "at", "in", "by"]
+  },
+  {
+    "question": "We met ___ chance at the station.",
+    "correct": "by",
+    "choices": ["by", "at", "in", "on"]
+  },
+  {
+    "question": "He looked ___ the window to see the rain.",
+    "correct": "out of",
+    "choices": ["out", "out of", "from", "through"]
+  }
+]

--- a/src/data/quizzes/english3/lv9_conversation_selection.json
+++ b/src/data/quizzes/english3/lv9_conversation_selection.json
@@ -1,0 +1,52 @@
+[
+  {
+    "question": "A: How are you? B: ___",
+    "correct": "I'm fine, thanks.",
+    "choices": ["I'm fine, thanks.", "See you later.", "Good night.", "I like pizza."]
+  },
+  {
+    "question": "A: What's your name? B: ___",
+    "correct": "My name is Ken.",
+    "choices": ["I'm ten years old.", "My name is Ken.", "I live in Tokyo.", "Yes, please."]
+  },
+  {
+    "question": "A: Do you like soccer? B: ___",
+    "correct": "Yes, I do.",
+    "choices": ["Yes, I do.", "No, I can't.", "It's five o'clock.", "Nice to meet you."]
+  },
+  {
+    "question": "A: Where are you from? B: ___",
+    "correct": "I'm from Osaka.",
+    "choices": ["I'm from Osaka.", "I'm fine, thanks.", "See you tomorrow.", "I like music."]
+  },
+  {
+    "question": "A: What time is it? B: ___",
+    "correct": "It's three o'clock.",
+    "choices": ["It's three o'clock.", "I'm twelve years old.", "I like apples.", "Good morning."]
+  },
+  {
+    "question": "A: Can you help me? B: ___",
+    "correct": "Sure, what's wrong?",
+    "choices": ["Sure, what's wrong?", "I don't know.", "See you later.", "Yes, I am."]
+  },
+  {
+    "question": "A: Let's go to the park. B: ___",
+    "correct": "Sounds good!",
+    "choices": ["Sounds good!", "No, I don't.", "It's Monday.", "I'm from Tokyo."]
+  },
+  {
+    "question": "A: Thank you very much. B: ___",
+    "correct": "You're welcome.",
+    "choices": ["You're welcome.", "Yes, please.", "Good evening.", "I like games."]
+  },
+  {
+    "question": "A: See you tomorrow. B: ___",
+    "correct": "See you!",
+    "choices": ["See you!", "I'm hungry.", "That's mine.", "No problem."]
+  },
+  {
+    "question": "A: I'm hungry. B: ___",
+    "correct": "Let's eat something.",
+    "choices": ["Let's eat something.", "I live in Kyoto.", "It's sunny.", "Yes, I do."]
+  }
+]


### PR DESCRIPTION
## Summary
- add new English Level 3 quiz set with 10 levels covering passive voice, relative pronouns, verb tenses, comparisons, if clauses, reading comprehension, confusing verbs, advanced prepositions, conversation selection and error correction

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_685955d630448322a5f96125d2e54f4e