### PR TITLE
Expand english3 quizzes

### DIFF
--- a/src/data/quizzes/english3/lv10_error_correction.json
+++ b/src/data/quizzes/english3/lv10_error_correction.json
@@ -48,5 +48,55 @@
     "question": "正しい文を選択して。",
     "correct": "I'm interested in music.",
     "choices": ["I'm interest in music.", "I'm interesting in music.", "I'm interested in music.", "I interested in music."]
+  },
+  {
+    "question": "正しい文はどれ？",
+    "correct": "She has been to Paris.",
+    "choices": ["She have been to Paris.", "She has been to Paris.", "She has went to Paris.", "She been to Paris."]
+  },
+  {
+    "question": "正しい形を選んでください。",
+    "correct": "My brother doesn't like cheese.",
+    "choices": ["My brother don't like cheese.", "My brother doesn't like cheese.", "My brother isn't like cheese.", "My brother not like cheese."]
+  },
+  {
+    "question": "正しい文を選んでください。",
+    "correct": "There is a book on the table.",
+    "choices": ["There are a book on the table.", "There is a book on the table.", "There be a book on the table.", "There is book on the table."]
+  },
+  {
+    "question": "正しい比較の文はどれ？",
+    "correct": "He is taller than me.",
+    "choices": ["He is tall than me.", "He is taller than me.", "He is tallest than me.", "He is more tall than me."]
+  },
+  {
+    "question": "正しい進行形はどれ？",
+    "correct": "We were watching TV.",
+    "choices": ["We was watching TV.", "We were watching TV.", "We were watch TV.", "We watching TV."]
+  },
+  {
+    "question": "正しい疑問文はどれ？",
+    "correct": "Did you finish your homework?",
+    "choices": ["Do you finish your homework?", "Did you finish your homework?", "Did you finished your homework?", "You finished your homework?"]
+  },
+  {
+    "question": "正しい文はどれ？",
+    "correct": "I bought some apples.",
+    "choices": ["I buy some apples.", "I bought some apples.", "I buying some apples.", "I buys some apples."]
+  },
+  {
+    "question": "正しい現在完了形を選んで。",
+    "correct": "She has lived here for five years.",
+    "choices": ["She have lived here for five years.", "She has lived here for five years.", "She has live here for five years.", "She lived here for five years."]
+  },
+  {
+    "question": "正しい否定文はどれ？",
+    "correct": "They aren't ready yet.",
+    "choices": ["They isn't ready yet.", "They aren't ready yet.", "They not ready yet.", "They doesn't ready yet."]
+  },
+  {
+    "question": "正しい受け身の文はどれ？",
+    "correct": "This car was made in Japan.",
+    "choices": ["This car made in Japan.", "This car was made in Japan.", "This car is make in Japan.", "This car was making in Japan."]
   }
 ]

--- a/src/data/quizzes/english3/lv1_passive_voice.json
+++ b/src/data/quizzes/english3/lv1_passive_voice.json
@@ -98,5 +98,105 @@
       "Play the game.",
       "She is playing it."
     ]
+  },
+  {
+    "question": "受け身の文を選んで: The picture ___ by Tom.",
+    "correct": "was painted",
+    "choices": [
+      "painted",
+      "was painted",
+      "is painting",
+      "paints"
+    ]
+  },
+  {
+    "question": "受け身を正しく使っているのはどれ？",
+    "correct": "The ball was kicked by him.",
+    "choices": [
+      "He kicks the ball.",
+      "The ball was kicked by him.",
+      "Kick the ball.",
+      "He is kicking the ball."
+    ]
+  },
+  {
+    "question": "受け身の文はどれ？: The car ___ tomorrow.",
+    "correct": "will be repaired",
+    "choices": [
+      "repairs",
+      "will be repaired",
+      "is repairing",
+      "repaired"
+    ]
+  },
+  {
+    "question": "受け身の形が使われている文を選んで。",
+    "correct": "The food is cooked.",
+    "choices": [
+      "Cook the food.",
+      "The food is cooked.",
+      "He cooks the food.",
+      "Cooking the food."
+    ]
+  },
+  {
+    "question": "受け身の文はどれ？: The laptop was fixed by the technician.",
+    "correct": "The laptop was fixed by the technician.",
+    "choices": [
+      "The technician fixes the laptop.",
+      "Fix the laptop.",
+      "The laptop was fixed by the technician.",
+      "He fixing the laptop."
+    ]
+  },
+  {
+    "question": "受け身の形を使っているのはどれ？",
+    "correct": "The story will be told.",
+    "choices": [
+      "The story will be told.",
+      "Tell the story.",
+      "He tells the story.",
+      "He is telling the story."
+    ]
+  },
+  {
+    "question": "受け身の文を探して。",
+    "correct": "The email was sent yesterday.",
+    "choices": [
+      "Send the email yesterday.",
+      "He sends the email yesterday.",
+      "The email was sent yesterday.",
+      "He is sending the email."
+    ]
+  },
+  {
+    "question": "正しい受け身を選んで。",
+    "correct": "The cake is being baked.",
+    "choices": [
+      "The cake is being baked.",
+      "Bake the cake.",
+      "He baked the cake.",
+      "He is baking the cake."
+    ]
+  },
+  {
+    "question": "どれが受け身？",
+    "correct": "The dog was saved.",
+    "choices": [
+      "Save the dog.",
+      "He saves the dog.",
+      "The dog was saved.",
+      "He is saving the dog."
+    ]
+  },
+  {
+    "question": "受け身を使う文はどれ？",
+    "correct": "The homework will be done.",
+    "choices": [
+      "Do the homework.",
+      "He does the homework.",
+      "The homework will be done.",
+      "He is doing the homework."
+    ]
   }
 ]

--- a/src/data/quizzes/english3/lv2_relative_pronouns.json
+++ b/src/data/quizzes/english3/lv2_relative_pronouns.json
@@ -58,5 +58,55 @@
     "question": "空欄を埋める関係代名詞はどれ？: The house ___ Jack built is old.",
     "correct": "that",
     "choices": ["who", "that", "where", "whose"]
+  },
+  {
+    "question": "空欄に入る関係代名詞は？: The boy ___ I met yesterday was kind.",
+    "correct": "whom",
+    "choices": ["who", "whom", "whose", "where"]
+  },
+  {
+    "question": "関係代名詞を選んで: This is the place ___ we first met.",
+    "correct": "where",
+    "choices": ["who", "which", "where", "that"]
+  },
+  {
+    "question": "空欄に入る関係代名詞は？: I remember the day ___ we graduated.",
+    "correct": "when",
+    "choices": ["when", "where", "who", "which"]
+  },
+  {
+    "question": "どの関係代名詞？: The man ___ car was stolen reported it.",
+    "correct": "whose",
+    "choices": ["whose", "who", "which", "whom"]
+  },
+  {
+    "question": "正しい関係代名詞を選ぼう: She likes people ___ are honest.",
+    "correct": "who",
+    "choices": ["who", "whose", "which", "whom"]
+  },
+  {
+    "question": "空欄に入るのは？: This is the book ___ covers grammar well.",
+    "correct": "that",
+    "choices": ["who", "where", "that", "when"]
+  },
+  {
+    "question": "正しい関係代名詞はどれ？: The movie ___ we watched was exciting.",
+    "correct": "which",
+    "choices": ["who", "which", "where", "whose"]
+  },
+  {
+    "question": "空欄に入れる関係代名詞: I have a friend ___ speaks three languages.",
+    "correct": "who",
+    "choices": ["who", "where", "which", "whom"]
+  },
+  {
+    "question": "空欄に入る関係代名詞を選んで: The town ___ I was born is small.",
+    "correct": "where",
+    "choices": ["who", "which", "where", "whose"]
+  },
+  {
+    "question": "適切な関係代名詞は？: The teacher ___ class I took is strict.",
+    "correct": "whose",
+    "choices": ["whom", "whose", "who", "where"]
   }
 ]

--- a/src/data/quizzes/english3/lv3_verb_tenses.json
+++ b/src/data/quizzes/english3/lv3_verb_tenses.json
@@ -48,5 +48,55 @@
     "question": "すでに終わっていることを表す形は？: He ___ already finished his project.",
     "correct": "has",
     "choices": ["has", "have", "had", "will have"]
+  },
+  {
+    "question": "昨日の時点ですでに終えていた？: She ___ her homework before dinner.",
+    "correct": "had finished",
+    "choices": ["finished", "had finished", "has finished", "finishes"]
+  },
+  {
+    "question": "この時間明日は何をしている？: This time tomorrow, I ___ on the beach.",
+    "correct": "will be lying",
+    "choices": ["lie", "will lie", "will be lying", "lying"]
+  },
+  {
+    "question": "過去進行形を選んで: They ___ TV when I arrived.",
+    "correct": "were watching",
+    "choices": ["watched", "were watching", "watch", "watching"]
+  },
+  {
+    "question": "現在完了形を選んで: We ___ in this city for ten years.",
+    "correct": "have lived",
+    "choices": ["live", "lived", "have lived", "will live"]
+  },
+  {
+    "question": "未来形を選んで: I ___ you later.",
+    "correct": "will call",
+    "choices": ["call", "called", "will call", "calling"]
+  },
+  {
+    "question": "現在形に合うものは？: He ___ coffee every morning.",
+    "correct": "drinks",
+    "choices": ["drinks", "drink", "drank", "drinking"]
+  },
+  {
+    "question": "過去形を選んで: They ___ to the concert last night.",
+    "correct": "went",
+    "choices": ["go", "goes", "went", "going"]
+  },
+  {
+    "question": "過去完了形を選ぼう: By the time we arrived, the movie ___.",
+    "correct": "had started",
+    "choices": ["started", "had started", "has started", "starts"]
+  },
+  {
+    "question": "現在進行形はどれ？: She ___ for her test right now.",
+    "correct": "is studying",
+    "choices": ["studies", "studied", "is studying", "will study"]
+  },
+  {
+    "question": "未来完了進行形を選んで: Next year he ___ for five years.",
+    "correct": "will have been working",
+    "choices": ["will work", "has worked", "will have been working", "works"]
   }
 ]

--- a/src/data/quizzes/english3/lv4_comparison.json
+++ b/src/data/quizzes/english3/lv4_comparison.json
@@ -48,5 +48,55 @@
     "question": "ほかの誰より上手いことを表す語は？: She sings ___ than anyone else.",
     "correct": "better",
     "choices": ["good", "better", "best", "well"]
+  },
+  {
+    "question": "空欄に入る比較級は？: This road is ___ than that one.",
+    "correct": "narrower",
+    "choices": ["narrower", "narrow", "narrowest", "more narrow"]
+  },
+  {
+    "question": "最高級を用いるのは？: She is the ___ singer in our school.",
+    "correct": "best",
+    "choices": ["good", "better", "best", "well"]
+  },
+  {
+    "question": "比較級はどれ？: My house is ___ than yours.",
+    "correct": "bigger",
+    "choices": ["big", "bigger", "biggest", "most big"]
+  },
+  {
+    "question": "最上級を選んで: That was the ___ day of my life.",
+    "correct": "happiest",
+    "choices": ["happy", "happier", "happiest", "most happy"]
+  },
+  {
+    "question": "比較級を選んで: This test is ___ than the last one.",
+    "correct": "harder",
+    "choices": ["harder", "hardest", "hard", "more hard"]
+  },
+  {
+    "question": "最上級を使うのは？: He is the ___ of the three brothers.",
+    "correct": "oldest",
+    "choices": ["old", "older", "oldest", "more old"]
+  },
+  {
+    "question": "比較級を選ぼう: Today's weather is ___ than yesterday.",
+    "correct": "better",
+    "choices": ["good", "better", "best", "well"]
+  },
+  {
+    "question": "最上級を選んで: It was the ___ performance of the year.",
+    "correct": "worst",
+    "choices": ["bad", "worse", "worst", "baddest"]
+  },
+  {
+    "question": "比較級はどれ？: My sister is ___ than me.",
+    "correct": "younger",
+    "choices": ["young", "younger", "youngest", "more young"]
+  },
+  {
+    "question": "最上級を使っているのは？: This puzzle is the ___ I've ever solved.",
+    "correct": "hardest",
+    "choices": ["hard", "harder", "hardest", "most hard"]
   }
 ]

--- a/src/data/quizzes/english3/lv5_if_clauses.json
+++ b/src/data/quizzes/english3/lv5_if_clauses.json
@@ -48,5 +48,55 @@
     "question": "明日雨が降ったら？: If it ___ tomorrow, the event will stop.",
     "correct": "rains",
     "choices": ["rain", "rained", "rains", "raining"]
+  },
+  {
+    "question": "もし鍵をなくしたら？: If you lose your key, you ___ enter the house.",
+    "correct": "can't",
+    "choices": ["can", "can't", "could", "will"]
+  },
+  {
+    "question": "もし彼女が来たら、___ me know.",
+    "correct": "let",
+    "choices": ["lets", "letting", "let", "to let"]
+  },
+  {
+    "question": "もし時間があったら旅行したい: If I had time, I ___ travel.",
+    "correct": "would travel",
+    "choices": ["travel", "traveled", "would travel", "travels"]
+  },
+  {
+    "question": "もし車を持っていたら？: If he had a car, he ___ drive to work.",
+    "correct": "would drive",
+    "choices": ["drive", "drove", "would drive", "driving"]
+  },
+  {
+    "question": "もし試験に合格したら？: If you pass the exam, I ___ you a gift.",
+    "correct": "will give",
+    "choices": ["give", "gave", "will give", "giving"]
+  },
+  {
+    "question": "もし雨が止んだら？: If the rain stops, we ___ out.",
+    "correct": "will go",
+    "choices": ["go", "went", "will go", "going"]
+  },
+  {
+    "question": "もし昨日それを知っていたら？: If I had known, I ___ you.",
+    "correct": "would have told",
+    "choices": ["tell", "told", "would tell", "would have told"]
+  },
+  {
+    "question": "もし明日早く起きたら？: If she gets up early, she ___ the train.",
+    "correct": "will catch",
+    "choices": ["catch", "will catch", "catches", "catching"]
+  },
+  {
+    "question": "もし私が彼を見かけたら？: If I see him, I ___ hello.",
+    "correct": "will say",
+    "choices": ["say", "said", "will say", "saying"]
+  },
+  {
+    "question": "もしあなたがここにいたらどうする？: What ___ if you were here?",
+    "correct": "would you do",
+    "choices": ["do you do", "will you do", "would you do", "are you doing"]
   }
 ]

--- a/src/data/quizzes/english3/lv6_reading_comprehension.json
+++ b/src/data/quizzes/english3/lv6_reading_comprehension.json
@@ -48,5 +48,55 @@
     "question": "電車は遅れて到着しました。どう到着しましたか？",
     "correct": "late",
     "choices": ["early", "on time", "late", "quickly"]
+  },
+  {
+    "question": "Mikeは毎朝ジョギングをします。何をしますか？",
+    "correct": "jogs",
+    "choices": ["jogs", "swims", "reads", "sleeps"]
+  },
+  {
+    "question": "店は9時に開きます。何時に開きますか？",
+    "correct": "at nine",
+    "choices": ["at eight", "at nine", "at ten", "at seven"]
+  },
+  {
+    "question": "Lucyは夜にテレビを見ました。いつ見ましたか？",
+    "correct": "at night",
+    "choices": ["in the morning", "at noon", "at night", "in the afternoon"]
+  },
+  {
+    "question": "彼らはパンと牛乳を買いました。牛乳以外に何を買いましたか？",
+    "correct": "bread",
+    "choices": ["bread", "rice", "meat", "fish"]
+  },
+  {
+    "question": "Tomは図書館で勉強しました。どこで勉強しましたか？",
+    "correct": "at the library",
+    "choices": ["at home", "at school", "at the library", "at the park"]
+  },
+  {
+    "question": "Saraは新しい自転車を買いました。何を買いましたか？",
+    "correct": "a new bike",
+    "choices": ["a new car", "a new book", "a new bike", "a new pen"]
+  },
+  {
+    "question": "昨日はとても暑かったです。どんな天気でしたか？",
+    "correct": "hot",
+    "choices": ["cold", "rainy", "hot", "snowy"]
+  },
+  {
+    "question": "彼は昼食にサンドイッチを食べました。何を食べましたか？",
+    "correct": "a sandwich",
+    "choices": ["soup", "rice", "a sandwich", "salad"]
+  },
+  {
+    "question": "私たちはバスで学校に行きました。何で行きましたか？",
+    "correct": "by bus",
+    "choices": ["by car", "on foot", "by bus", "by bike"]
+  },
+  {
+    "question": "彼女は1時間ピアノを練習しました。何をしましたか？",
+    "correct": "practiced the piano",
+    "choices": ["practiced the piano", "played soccer", "watched TV", "read a book"]
   }
 ]

--- a/src/data/quizzes/english3/lv7_word_usage.json
+++ b/src/data/quizzes/english3/lv7_word_usage.json
@@ -48,5 +48,55 @@
     "question": "彼はすぐ来ると___。空欄は？: He ___ he would come soon.",
     "correct": "said",
     "choices": ["spoke", "said", "told", "talked"]
+  },
+  {
+    "question": "彼に秘密を___ないで。空欄は？: Don't ___ him the secret.",
+    "correct": "tell",
+    "choices": ["tell", "say", "speak", "talk"]
+  },
+  {
+    "question": "式で一言___ください。空欄は？: Please ___ a few words at the ceremony.",
+    "correct": "say",
+    "choices": ["tell", "speak", "say", "talk"]
+  },
+  {
+    "question": "そのトピックについて___しましょうか。: Shall we ___ about that topic?",
+    "correct": "talk",
+    "choices": ["say", "tell", "talk", "speak"]
+  },
+  {
+    "question": "彼は英語を___のが上手です。: He can ___ English well.",
+    "correct": "speak",
+    "choices": ["speak", "say", "tell", "talk"]
+  },
+  {
+    "question": "彼女は『こんにちは』と___。: She ___ \"hello.\"",
+    "correct": "said",
+    "choices": ["said", "told", "spoke", "talked"]
+  },
+  {
+    "question": "彼女に真実を___べきだ。: You should ___ her the truth.",
+    "correct": "tell",
+    "choices": ["say", "tell", "talk", "speak"]
+  },
+  {
+    "question": "彼らは電話で___ことが好きだ。: They like to ___ on the phone.",
+    "correct": "talk",
+    "choices": ["talk", "say", "tell", "speak"]
+  },
+  {
+    "question": "発表で___ことがありますか？: Do you want to ___ at the presentation?",
+    "correct": "speak",
+    "choices": ["speak", "tell", "say", "talk"]
+  },
+  {
+    "question": "先生は生徒に静かにするよう___。: The teacher ___ the students to be quiet.",
+    "correct": "told",
+    "choices": ["said", "told", "spoke", "saying"]
+  },
+  {
+    "question": "彼にありがとうと___。: ___ thank you to him.",
+    "correct": "Say",
+    "choices": ["Say", "Tell", "Speak", "Talk"]
   }
 ]

--- a/src/data/quizzes/english3/lv8_prepositions_advanced.json
+++ b/src/data/quizzes/english3/lv8_prepositions_advanced.json
@@ -48,5 +48,55 @@
     "question": "He looked ___ the window to see the rain. 空欄に入る前置詞は？",
     "correct": "out of",
     "choices": ["out", "out of", "from", "through"]
+  },
+  {
+    "question": "She walked ___ the bridge to the other side. 空欄に入る前置詞は？",
+    "correct": "across",
+    "choices": ["across", "through", "along", "over"]
+  },
+  {
+    "question": "Put the books ___ the shelf. 空欄に入る前置詞は？",
+    "correct": "on",
+    "choices": ["in", "on", "at", "by"]
+  },
+  {
+    "question": "He sat ___ the table during lunch. 空欄に入る前置詞は？",
+    "correct": "at",
+    "choices": ["at", "on", "in", "over"]
+  },
+  {
+    "question": "We drove ___ the tunnel to the city. 空欄に入る前置詞は？",
+    "correct": "through",
+    "choices": ["across", "along", "through", "over"]
+  },
+  {
+    "question": "The picture is hung ___ the wall. 空欄に入る前置詞は？",
+    "correct": "on",
+    "choices": ["on", "in", "at", "over"]
+  },
+  {
+    "question": "She lives ___ the corner of the street. 空欄に入る前置詞は？",
+    "correct": "at",
+    "choices": ["at", "in", "on", "by"]
+  },
+  {
+    "question": "He put the key ___ his pocket. 空欄に合う前置詞は？",
+    "correct": "in",
+    "choices": ["in", "on", "at", "to"]
+  },
+  {
+    "question": "We arrived ___ the airport early. 空欄に入る前置詞は？",
+    "correct": "at",
+    "choices": ["at", "in", "on", "by"]
+  },
+  {
+    "question": "The cat is hiding ___ the bed. 空欄に入る前置詞は？",
+    "correct": "under",
+    "choices": ["under", "below", "over", "on"]
+  },
+  {
+    "question": "They walked ___ the beach enjoying the sunset. 空欄に入る前置詞は？",
+    "correct": "along",
+    "choices": ["along", "across", "through", "over"]
   }
 ]

--- a/src/data/quizzes/english3/lv9_conversation_selection.json
+++ b/src/data/quizzes/english3/lv9_conversation_selection.json
@@ -48,5 +48,55 @@
     "question": "A: I'm hungry. B: ___ に入る返事はどれ？",
     "correct": "Let's eat something.",
     "choices": ["Let's eat something.", "I live in Kyoto.", "It's sunny.", "Yes, I do."]
+  },
+  {
+    "question": "A: Where is the station? B: ___ に入る答えは？",
+    "correct": "It's over there.",
+    "choices": ["It's over there.", "I don't know.", "See you later.", "I'm fine."]
+  },
+  {
+    "question": "A: Do you want coffee? B: ___ に入る返事は？",
+    "correct": "Yes, please.",
+    "choices": ["Yes, please.", "I like tea.", "Good afternoon.", "No, I can't."]
+  },
+  {
+    "question": "A: Good night. B: ___ に入る言葉は？",
+    "correct": "Good night.",
+    "choices": ["Good night.", "Good morning.", "I'm good.", "See you!"]
+  },
+  {
+    "question": "A: How old are you? B: ___ に入る答えは？",
+    "correct": "I'm fifteen.",
+    "choices": ["I'm fifteen.", "I'm fine.", "See you tomorrow.", "I don't know."]
+  },
+  {
+    "question": "A: What's the matter? B: ___ に入る返事は？",
+    "correct": "I have a headache.",
+    "choices": ["I have a headache.", "Nice to meet you.", "I'm Ken.", "It's nine o'clock."]
+  },
+  {
+    "question": "A: Can I help you? B: ___ に入る返事は？",
+    "correct": "No, thank you.",
+    "choices": ["No, thank you.", "Yes, I can.", "I'm happy.", "That's great."]
+  },
+  {
+    "question": "A: Do you play tennis? B: ___ に入る答えは？",
+    "correct": "Not really.",
+    "choices": ["Not really.", "I'm fine.", "It's sunny.", "See you later."]
+  },
+  {
+    "question": "A: What do you do? B: ___ に入る返事は？",
+    "correct": "I'm a student.",
+    "choices": ["I'm a student.", "I like dogs.", "See you soon.", "Yes, please."]
+  },
+  {
+    "question": "A: See you next week. B: ___ に入る言葉は？",
+    "correct": "See you then!",
+    "choices": ["See you then!", "I'm tired.", "That's too bad.", "No, thanks."]
+  },
+  {
+    "question": "A: Is this seat taken? B: ___ に入る返事は？",
+    "correct": "No, it's free.",
+    "choices": ["No, it's free.", "Yes, you can.", "I don't think so.", "See you."]
   }
 ]


### PR DESCRIPTION
## Summary
- add ten new items to each English level 3 quiz set

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d4b15c3988322958a30eb6c8d2679